### PR TITLE
Revert "fix: instruct the controller to stop retrying under specific circumstances"

### DIFF
--- a/controllers/apps/configuration/sync_upgrade_policy.go
+++ b/controllers/apps/configuration/sync_upgrade_policy.go
@@ -98,9 +98,6 @@ func sync(params reconfigureParams, updatedParameters map[string]string, pods []
 		return makeReturnedStatus(ESFailedAndRetry), err
 	}
 	if len(pods) == 0 {
-		if replicas == 0 {
-			return makeReturnedStatus(ESNone), nil
-		}
 		params.Ctx.Log.Info(fmt.Sprintf("no pods to update, and retry, selector: %v", selector))
 		return makeReturnedStatus(ESRetry), nil
 	}

--- a/controllers/apps/transformer_component_validation.go
+++ b/controllers/apps/transformer_component_validation.go
@@ -91,9 +91,7 @@ func validateCompReplicas(comp *appsv1alpha1.Component, compDef *appsv1alpha1.Co
 		replicasLimit = compDef.Spec.ReplicasLimit
 	}
 	replicas := comp.Spec.Replicas
-	// Allow replicas=0 (stopped state) to pass validation, as stopping a cluster is a valid operation.
-	// This prevents infinite requeue loops for stopped clusters.
-	if replicas == 0 || (replicas >= replicasLimit.MinReplicas && replicas <= replicasLimit.MaxReplicas) {
+	if replicas >= replicasLimit.MinReplicas && replicas <= replicasLimit.MaxReplicas {
 		return nil
 	}
 	return replicasOutOfLimitError(replicas, *replicasLimit)


### PR DESCRIPTION
Reverts labring/kubeblocks#1
May cause MongoDB to status become Updating.