### PR TITLE
fix(dataprotection): prevent infinite job creation loop during backup…

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -197,6 +197,13 @@ func (r *BackupReconciler) parseBackupJob(_ context.Context, object client.Objec
 
 // deleteBackupFiles deletes the backup files stored in backup repository.
 func (r *BackupReconciler) deleteBackupFiles(reqCtx intctrlutil.RequestCtx, backup *dpv1alpha1.Backup) error {
+	// If the dataprotection finalizer has already been removed, the deletion has succeeded.
+	// Skip creating a new deletion job to avoid a race condition with the garbage collector
+	// during foreground cascading deletion, which would cause an infinite loop of job creation.
+	if !controllerutil.ContainsFinalizer(backup, dptypes.DataProtectionFinalizerName) {
+		return nil
+	}
+
 	deleteBackup := func() error {
 		// remove backup finalizers to delete it
 		patch := client.MergeFrom(backup.DeepCopy())


### PR DESCRIPTION
… foreground deletion

When a Backup is deleted using foreground cascading deletion, the garbage collector actively deletes all child resources with blockOwnerDeletion=true. This caused a race condition where:

1. Backup Controller creates a deletion job (with blockOwnerDeletion=true)
2. GC detects the new blocking child resource and deletes it
3. Backup Controller sees the job is missing and creates a new one
4. This creates an infinite loop of job creation/deletion

The fix checks if the dataprotection finalizer has already been removed before creating a new deletion job. If the finalizer is gone, the deletion has already succeeded and no new job should be created.