### PR TITLE
feat: transformer account and service backward compatibility

### DIFF
--- a/controllers/apps/transformer_component_account.go
+++ b/controllers/apps/transformer_component_account.go
@@ -140,10 +140,32 @@ func (t *componentAccountTransformer) buildPassword(ctx *componentTransformConte
 		// This is compatibility processing.
 		password = factory.GetRestorePassword(ctx.Cluster, ctx.SynthesizeComponent)
 	}
+	// Try to get password from legacy conn-credential secret for backward compatibility (0.8 -> 0.9 upgrade).
+	if account.InitAccount && password == "" {
+		password = t.getPasswordFromLegacySecret(ctx)
+	}
 	if password == "" {
 		return t.generatePassword(account)
 	}
 	return []byte(password)
+}
+
+// getPasswordFromLegacySecret attempts to get password from legacy conn-credential secret.
+// This is for backward compatibility when upgrading from 0.8 to 0.9.
+func (t *componentAccountTransformer) getPasswordFromLegacySecret(ctx *componentTransformContext) string {
+	legacySecretName := constant.GenerateDefaultConnCredential(ctx.SynthesizeComponent.ClusterName)
+	secretKey := types.NamespacedName{
+		Namespace: ctx.SynthesizeComponent.Namespace,
+		Name:      legacySecretName,
+	}
+	secret := &corev1.Secret{}
+	if err := ctx.GetClient().Get(ctx.GetContext(), secretKey, secret); err != nil {
+		return ""
+	}
+	if password, ok := secret.Data[constant.AccountPasswdForSecret]; ok && len(password) > 0 {
+		return string(password)
+	}
+	return ""
 }
 
 func (t *componentAccountTransformer) generatePassword(account appsv1alpha1.SystemAccount) []byte {

--- a/controllers/apps/transformer_component_service.go
+++ b/controllers/apps/transformer_component_service.go
@@ -90,10 +90,40 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	for svc := range runningServices {
+		// Keep legacy services for backward compatibility (0.8 -> 0.9 upgrade).
+		// If a service name matches the legacy format ({cluster}-{component}) and it's not defined
+		// in current ComponentServices, keep it instead of deleting.
+		if t.isLegacyService(synthesizeComp, svc) {
+			continue
+		}
 		graphCli.Delete(dag, runningServices[svc], inDataContext4G())
 	}
 
 	return nil
+}
+
+// isLegacyService checks if a service is a legacy service that should be kept for backward compatibility.
+// Legacy services have the format {cluster}-{component} and were created in older versions (0.8).
+// In newer versions (0.9+), services may have additional suffix like {cluster}-{component}-{serviceName}.
+func (t *componentServiceTransformer) isLegacyService(synthesizeComp *component.SynthesizedComponent, svcName string) bool {
+	// Generate the legacy default service name: {cluster}-{component}
+	legacyDefaultSvcName := constant.GenerateDefaultComponentServiceName(synthesizeComp.ClusterName, synthesizeComp.Name)
+	if svcName != legacyDefaultSvcName {
+		return false
+	}
+
+	// Check if any current service would generate the same name as legacy service.
+	// If so, it's not a legacy service that needs to be kept.
+	for _, service := range synthesizeComp.ComponentServices {
+		currentSvcName := constant.GenerateComponentServiceName(synthesizeComp.ClusterName, synthesizeComp.Name, service.ServiceName)
+		if currentSvcName == legacyDefaultSvcName {
+			// Current service definition generates the same name, not a legacy service
+			return false
+		}
+	}
+
+	// This is a legacy service: name matches {cluster}-{component} but no current service generates this name
+	return true
 }
 
 func (t *componentServiceTransformer) listOwnedServices(ctx context.Context, cli client.Reader,


### PR DESCRIPTION
## Background

When upgrading from KubeBlocks 0.8 to 0.9, the account and service naming conventions have changed:
- **Account**: 0.8 uses `{cluster}-conn-credential` secret, 0.9 uses `{cluster}-{component}-account-{accountName}` secret
- **Service**: 0.8 uses `{cluster}-{component}` format, 0.9 uses `{cluster}-{component}-{serviceName}` format

This causes issues during upgrade:
1. New account secrets are created with different passwords, breaking existing connections
2. Legacy services may be incorrectly deleted, causing service disruption

## Problem

### Account Issue
- When upgrading from 0.8 to 0.9, if the new account secret is deleted (manually or by accident), it gets recreated with a new random password
- The legacy password stored in the old `{cluster}-conn-credential` secret is not preserved
- This breaks database connections for applications using the old credentials

### Service Issue
- During component reconciliation, the controller may delete services that don't match current ComponentServices definitions
- Legacy services with the `{cluster}-{component}` format are treated as orphaned and deleted
- This causes service interruption for clients using the legacy service names

## Solution

### Account Transformer (`transformer_component_account.go`)
Added `getPasswordFromLegacySecret()` method:
- When creating a new account, first check if a legacy `{cluster}-conn-credential` secret exists
- If found, extract the password from the `password` field
- Use the legacy password for the new account instead of generating a random one
- Ensures password consistency across versions

### Service Transformer (`transformer_component_service.go`)
Added `isLegacyService()` method:
- Before deleting a service, check if it matches the legacy naming format `{cluster}-{component}`
- Verify that no current ComponentServices definition would generate the same name
- If both conditions are true, skip deletion and preserve the legacy service
- Only delete services that are truly orphaned

## Testing

### Account Test
1. Create a Redis cluster on 0.9.3
2. Create a legacy secret: `test-redis-conn-credential` with password `legacy-password-123`
3. Delete the new account secret: `test-redis-redis-account-default`
4. Verify the recreated account uses the legacy password

### Service Test
1. Create a Redis cluster on 0.9.3
2. Manually create a legacy service: `test-redis-redis` with ownerReference
3. Trigger component reconciliation
4. Verify the legacy service is not deleted

## Impact

- Ensures smooth upgrade path from 0.8 to 0.9
- Prevents connection disruption during account secret recreation
- Preserves legacy services to avoid client impact
- No breaking changes for new installations
