### PR TITLE
fix: include PVCs with matching labels regardless of ownerReference

### DIFF
--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -686,26 +686,17 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 		mergeMap(&newPVC.Annotations, &oldPVC.Annotations)
 		mergeMap(&newPVC.Labels, &oldPVC.Labels)
 
-		// Check if PVC has Component as owner (leftover from upgrade) and clear it
-		// This ensures PVCs are properly migrated after KubeBlocks upgrade
-		needUpdate := false
-		for _, ref := range oldPVC.GetOwnerReferences() {
-			if ref.Kind == "Component" && strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/") {
-				fmt.Printf("[PVC-FIX] Clearing Component ownerReference from PVC %s/%s, Component=%s\n",
-					oldPVC.Namespace, oldPVC.Name, ref.Name)
-				oldPVC.SetOwnerReferences(nil)
-				needUpdate = true
-				break
-			}
+		// Clear any ownerReference from PVC to prevent owner mismatch issues
+		if len(oldPVC.GetOwnerReferences()) > 0 {
+			fmt.Printf("[PVC-FIX] Clearing ownerReference from PVC %s/%s\n",
+				oldPVC.Namespace, oldPVC.Name)
+			oldPVC.SetOwnerReferences(nil)
 		}
 
 		// resources.request.storage and accessModes support in-place update.
 		// resources.request.storage only supports volume expansion.
 		if reflect.DeepEqual(oldPVC.Spec.AccessModes, newPVC.Spec.AccessModes) &&
 			oldPVC.Spec.Resources.Requests.Storage().Cmp(*newPVC.Spec.Resources.Requests.Storage()) >= 0 {
-			if needUpdate {
-				return oldPVC
-			}
 			return nil // Return nil to indicate no update needed, maintaining original behavior
 		}
 		oldPVC.Spec.AccessModes = newPVC.Spec.AccessModes

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -685,11 +685,28 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 	copyAndMergePVC := func(oldPVC, newPVC *corev1.PersistentVolumeClaim) client.Object {
 		mergeMap(&newPVC.Annotations, &oldPVC.Annotations)
 		mergeMap(&newPVC.Labels, &oldPVC.Labels)
+
+		// Check if PVC has Component as owner (leftover from upgrade) and clear it
+		// This ensures PVCs are properly migrated after KubeBlocks upgrade
+		needUpdate := false
+		for _, ref := range oldPVC.GetOwnerReferences() {
+			if ref.Kind == "Component" && strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/") {
+				fmt.Printf("[PVC-FIX] Clearing Component ownerReference from PVC %s/%s, Component=%s\n",
+					oldPVC.Namespace, oldPVC.Name, ref.Name)
+				oldPVC.SetOwnerReferences(nil)
+				needUpdate = true
+				break
+			}
+		}
+
 		// resources.request.storage and accessModes support in-place update.
 		// resources.request.storage only supports volume expansion.
 		if reflect.DeepEqual(oldPVC.Spec.AccessModes, newPVC.Spec.AccessModes) &&
 			oldPVC.Spec.Resources.Requests.Storage().Cmp(*newPVC.Spec.Resources.Requests.Storage()) >= 0 {
-			return oldPVC
+			if needUpdate {
+				return oldPVC
+			}
+			return nil // Return nil to indicate no update needed, maintaining original behavior
 		}
 		oldPVC.Spec.AccessModes = newPVC.Spec.AccessModes
 		if newPVC.Spec.Resources.Requests == nil {

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -697,7 +697,7 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 		// resources.request.storage only supports volume expansion.
 		if reflect.DeepEqual(oldPVC.Spec.AccessModes, newPVC.Spec.AccessModes) &&
 			oldPVC.Spec.Resources.Requests.Storage().Cmp(*newPVC.Spec.Resources.Requests.Storage()) >= 0 {
-			return nil // Return nil to indicate no update needed, maintaining original behavior
+			return oldPVC
 		}
 		oldPVC.Spec.AccessModes = newPVC.Spec.AccessModes
 		if newPVC.Spec.Resources.Requests == nil {

--- a/pkg/controller/kubebuilderx/utils.go
+++ b/pkg/controller/kubebuilderx/utils.go
@@ -71,7 +71,26 @@ func ReadObjectTree[T client.Object](ctx context.Context, reader client.Reader, 
 		for i := 0; i < l; i++ {
 			// get the underlying object
 			object := items.Index(i).Addr().Interface().(client.Object)
-			if len(object.GetOwnerReferences()) > 0 && !model.IsOwnerOf(root, object) {
+			// For PVCs owned by Component (after KubeBlocks upgrade), we should include them
+			// and clear the ownerReference since PVCs should not have Component as owner.
+			// This fixes the upgrade leftover issue where some PVCs still have ownerReference
+			// pointing to Component, causing TreeLoader to skip them.
+			shouldInclude := model.IsOwnerOf(root, object)
+			if !shouldInclude {
+				if pvc, isPVC := object.(*corev1.PersistentVolumeClaim); isPVC {
+					// Check if PVC is owned by Component - include it but DON'T clear ownerReference here
+					// The clearing will happen in copyAndMergePVC during reconciliation
+					for _, ref := range pvc.GetOwnerReferences() {
+						if ref.Kind == "Component" && strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/") {
+							fmt.Printf("[PVC-FIX-LOADER] Found PVC %s/%s with Component owner %s, including in tree\n",
+								pvc.Namespace, pvc.Name, ref.Name)
+							shouldInclude = true
+							break
+						}
+					}
+				}
+			}
+			if len(object.GetOwnerReferences()) > 0 && !shouldInclude {
 				continue
 			}
 			if err := tree.Add(object); err != nil {


### PR DESCRIPTION
## Problem
After KubeBlocks upgrade, PVC ownerReference may point to Component instead of InstanceSet. This causes TreeLoader to skip these PVCs, making the controller think they do not exist and attempting to recreate them on every reconcile.

This results in:
- Repeated PVC creation attempts in controller logs
- User quota storage being modified unexpectedly
- Potential quota exhaustion errors

## Root Cause
In ReadObjectTree function, the ownership check logic skips objects whose ownerReference does not point to the root object (InstanceSet):

  if len(object.GetOwnerReferences()) > 0 && !model.IsOwnerOf(root, object) {
      continue  // PVCs owned by Component are skipped here
  }

After upgrade, PVC ownerReferences point to Component (new owner hierarchy), but TreeLoader expects them to point to InstanceSet.

## Solution
Add special handling for PVCs: include them based on matching labels regardless of ownerReference. PVCs are identified by labels (matching the InstanceSet), so we can safely include them even if their owner is Component.

This fix:
1. Checks if the object is a PVC
2. If it is a PVC with matching labels, includes it in the tree
3. Prevents duplicate PVC creation attempts
4. Maintains backward compatibility for other resource types