### PR TITLE
fix: auto member join for mongodb

### DIFF
--- a/controllers/apps/transformer_component_workload.go
+++ b/controllers/apps/transformer_component_workload.go
@@ -631,6 +631,8 @@ func (r *componentWorkloadOps) memberJoinEnabled() bool {
 	if r.synthesizeComp.LifecycleActions != nil && r.synthesizeComp.LifecycleActions.MemberJoin != nil {
 		return true
 	}
+	// MongoDB with a roleProbe builtin handler can perform member joins via lorry
+	// even without an explicit MemberJoin action configuration.
 	if r.synthesizeComp.CharacterType != constant.MongoDBCharacterType {
 		return false
 	}
@@ -671,15 +673,19 @@ func (r *componentWorkloadOps) detectPodsToMemberJoin(pods []*corev1.Pod) sets.S
 		if pod == nil {
 			continue
 		}
+		// Skip pods not in desired set.
 		if !r.desiredCompPodNameSet.Has(pod.Name) {
 			continue
 		}
-		if !intctrlutil.PodIsReady(pod) && (pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil) {
+		// Skip pods being deleted, or neither ready nor running.
+		if pod.DeletionTimestamp != nil || (!intctrlutil.PodIsReady(pod) && pod.Status.Phase != corev1.PodRunning) {
 			continue
 		}
+		// Skip pods already reported as members.
 		if memberSet.Has(pod.Name) {
 			continue
 		}
+		// Skip pods with existing role labels.
 		if pod.Labels != nil {
 			if roleName, ok := pod.Labels[constant.RoleLabelKey]; ok && roleName != "" {
 				continue
@@ -796,7 +802,7 @@ func (r *componentWorkloadOps) leaveMemberForPod(pod *corev1.Pod, pods []*corev1
 
 func (r *componentWorkloadOps) checkAndDoMemberJoin() error {
 	// just wait for memberjoin anno to be updated
-	if r.protoITS.Annotations[constant.MemberJoinStatusAnnotationKey] != "" {
+	if r.protoITS.Annotations != nil && r.protoITS.Annotations[constant.MemberJoinStatusAnnotationKey] != "" {
 		return nil
 	}
 	if !r.memberJoinEnabled() {
@@ -804,9 +810,11 @@ func (r *componentWorkloadOps) checkAndDoMemberJoin() error {
 	}
 
 	podsToMemberjoin := getPodsToMemberJoinFromAnno(r.runningITS)
+	var runningPods []*corev1.Pod
 	if len(podsToMemberjoin) == 0 {
 		labels := constant.GetComponentWellKnownLabels(r.synthesizeComp.ClusterName, r.synthesizeComp.Name)
-		runningPods, err := component.ListPodOwnedByComponent(r.reqCtx.Ctx, r.cli, r.synthesizeComp.Namespace, labels, inDataContext4C())
+		var err error
+		runningPods, err = component.ListPodOwnedByComponent(r.reqCtx.Ctx, r.cli, r.synthesizeComp.Namespace, labels, inDataContext4C())
 		if err != nil {
 			return fmt.Errorf("failed to list pods for member join detection: %w", err)
 		}
@@ -817,7 +825,7 @@ func (r *componentWorkloadOps) checkAndDoMemberJoin() error {
 		r.reqCtx.Log.Info("detected pods to member join", "pods", sets.List(podsToMemberjoin))
 	}
 
-	err := r.doMemberJoin(podsToMemberjoin)
+	err := r.doMemberJoin(podsToMemberjoin, runningPods)
 	if err != nil {
 		return err
 	}
@@ -857,7 +865,7 @@ func (r *componentWorkloadOps) precondition(name string, action *appsv1alpha1.Ac
 	return nil
 }
 
-func (r *componentWorkloadOps) doMemberJoin(podSet sets.Set[string]) error {
+func (r *componentWorkloadOps) doMemberJoin(podSet sets.Set[string], runningPods []*corev1.Pod) error {
 	if len(podSet) == 0 {
 		return nil
 	}
@@ -874,10 +882,13 @@ func (r *componentWorkloadOps) doMemberJoin(podSet sets.Set[string]) error {
 		return err
 	}
 
-	labels := constant.GetComponentWellKnownLabels(r.synthesizeComp.ClusterName, r.synthesizeComp.Name)
-	runningPods, err := component.ListPodOwnedByComponent(r.reqCtx.Ctx, r.cli, r.synthesizeComp.Namespace, labels, inDataContext4C())
-	if err != nil {
-		return fmt.Errorf("failed to list pods: %w", err)
+	if runningPods == nil {
+		labels := constant.GetComponentWellKnownLabels(r.synthesizeComp.ClusterName, r.synthesizeComp.Name)
+		var err error
+		runningPods, err = component.ListPodOwnedByComponent(r.reqCtx.Ctx, r.cli, r.synthesizeComp.Namespace, labels, inDataContext4C())
+		if err != nil {
+			return fmt.Errorf("failed to list pods: %w", err)
+		}
 	}
 
 	var joinErrors []error

--- a/controllers/apps/transformer_component_workload.go
+++ b/controllers/apps/transformer_component_workload.go
@@ -586,7 +586,7 @@ func getHealthyLorryClient(pods []*corev1.Pod) (lorry.Client, error) {
 }
 
 func (r *componentWorkloadOps) annotateInstanceSetForMemberJoin() {
-	if r.synthesizeComp.LifecycleActions == nil || r.synthesizeComp.LifecycleActions.MemberJoin == nil {
+	if !r.memberJoinEnabled() {
 		return
 	}
 
@@ -619,6 +619,73 @@ func getPodsToMemberJoinFromAnno(instanceSet *workloads.InstanceSet) sets.Set[st
 
 	if memberJoinStatus := instanceSet.Annotations[constant.MemberJoinStatusAnnotationKey]; memberJoinStatus != "" {
 		podsToMemberjoin.Insert(strings.Split(memberJoinStatus, ",")...)
+	}
+
+	return podsToMemberjoin
+}
+
+func (r *componentWorkloadOps) memberJoinEnabled() bool {
+	if r.synthesizeComp == nil {
+		return false
+	}
+	if r.synthesizeComp.LifecycleActions != nil && r.synthesizeComp.LifecycleActions.MemberJoin != nil {
+		return true
+	}
+	if r.synthesizeComp.CharacterType != constant.MongoDBCharacterType {
+		return false
+	}
+	if r.synthesizeComp.LifecycleActions == nil || r.synthesizeComp.LifecycleActions.RoleProbe == nil {
+		return false
+	}
+	if r.synthesizeComp.LifecycleActions.RoleProbe.BuiltinHandler == nil {
+		return false
+	}
+	return *r.synthesizeComp.LifecycleActions.RoleProbe.BuiltinHandler == appsv1alpha1.MongoDBBuiltinActionHandler
+}
+
+func (r *componentWorkloadOps) detectPodsToMemberJoin(pods []*corev1.Pod) sets.Set[string] {
+	podsToMemberjoin := sets.New[string]()
+	if r.runningITS == nil || r.runningITS.Spec.Replicas == nil {
+		return podsToMemberjoin
+	}
+	if int(*r.runningITS.Spec.Replicas) <= len(r.runningITS.Status.MembersStatus) {
+		return podsToMemberjoin
+	}
+	hasLeader := false
+	for _, status := range r.runningITS.Status.MembersStatus {
+		if status.ReplicaRole != nil && status.ReplicaRole.IsLeader {
+			hasLeader = true
+			break
+		}
+	}
+	if !hasLeader {
+		return podsToMemberjoin
+	}
+
+	memberSet := sets.New[string]()
+	for _, status := range r.runningITS.Status.MembersStatus {
+		memberSet.Insert(status.PodName)
+	}
+
+	for _, pod := range pods {
+		if pod == nil {
+			continue
+		}
+		if !r.desiredCompPodNameSet.Has(pod.Name) {
+			continue
+		}
+		if !intctrlutil.PodIsReady(pod) && (pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil) {
+			continue
+		}
+		if memberSet.Has(pod.Name) {
+			continue
+		}
+		if pod.Labels != nil {
+			if roleName, ok := pod.Labels[constant.RoleLabelKey]; ok && roleName != "" {
+				continue
+			}
+		}
+		podsToMemberjoin.Insert(pod.Name)
 	}
 
 	return podsToMemberjoin
@@ -732,20 +799,32 @@ func (r *componentWorkloadOps) checkAndDoMemberJoin() error {
 	if r.protoITS.Annotations[constant.MemberJoinStatusAnnotationKey] != "" {
 		return nil
 	}
-
-	podsToMemberjoin := getPodsToMemberJoinFromAnno(r.runningITS)
-	if len(podsToMemberjoin) == 0 {
+	if !r.memberJoinEnabled() {
 		return nil
 	}
 
-	if r.synthesizeComp.LifecycleActions == nil || r.synthesizeComp.LifecycleActions.MemberJoin == nil {
-		podsToMemberjoin.Clear()
+	podsToMemberjoin := getPodsToMemberJoinFromAnno(r.runningITS)
+	if len(podsToMemberjoin) == 0 {
+		labels := constant.GetComponentWellKnownLabels(r.synthesizeComp.ClusterName, r.synthesizeComp.Name)
+		runningPods, err := component.ListPodOwnedByComponent(r.reqCtx.Ctx, r.cli, r.synthesizeComp.Namespace, labels, inDataContext4C())
+		if err != nil {
+			return fmt.Errorf("failed to list pods for member join detection: %w", err)
+		}
+		podsToMemberjoin = r.detectPodsToMemberJoin(runningPods)
+		if len(podsToMemberjoin) == 0 {
+			return nil
+		}
+		r.reqCtx.Log.Info("detected pods to member join", "pods", sets.List(podsToMemberjoin))
 	}
+
 	err := r.doMemberJoin(podsToMemberjoin)
 	if err != nil {
 		return err
 	}
 
+	if r.protoITS.Annotations == nil {
+		r.protoITS.Annotations = make(map[string]string)
+	}
 	r.protoITS.Annotations[constant.MemberJoinStatusAnnotationKey] = strings.Join(sets.List(podsToMemberjoin), ",")
 
 	return nil
@@ -783,11 +862,15 @@ func (r *componentWorkloadOps) doMemberJoin(podSet sets.Set[string]) error {
 		return nil
 	}
 
-	if r.synthesizeComp.LifecycleActions == nil || r.synthesizeComp.LifecycleActions.MemberJoin == nil {
+	if !r.memberJoinEnabled() {
 		return nil
 	}
 
-	if err := r.precondition(constant.MemberJoinAction, r.synthesizeComp.LifecycleActions.MemberJoin.CustomHandler); err != nil {
+	var action *appsv1alpha1.Action
+	if r.synthesizeComp.LifecycleActions != nil && r.synthesizeComp.LifecycleActions.MemberJoin != nil {
+		action = r.synthesizeComp.LifecycleActions.MemberJoin.CustomHandler
+	}
+	if err := r.precondition(constant.MemberJoinAction, action); err != nil {
 		return err
 	}
 

--- a/controllers/apps/transformer_component_workload_test.go
+++ b/controllers/apps/transformer_component_workload_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func TestMemberJoinEnabled(t *testing.T) {
+	t.Run("explicit member join", func(t *testing.T) {
+		op := &componentWorkloadOps{
+			synthesizeComp: &component.SynthesizedComponent{
+				LifecycleActions: &appsv1alpha1.ComponentLifecycleActions{
+					MemberJoin: &appsv1alpha1.LifecycleActionHandler{},
+				},
+			},
+		}
+		if !op.memberJoinEnabled() {
+			t.Fatal("expected member join to be enabled")
+		}
+	})
+
+	t.Run("mongodb role probe builtin", func(t *testing.T) {
+		handler := appsv1alpha1.MongoDBBuiltinActionHandler
+		op := &componentWorkloadOps{
+			synthesizeComp: &component.SynthesizedComponent{
+				CharacterType: constant.MongoDBCharacterType,
+				LifecycleActions: &appsv1alpha1.ComponentLifecycleActions{
+					RoleProbe: &appsv1alpha1.RoleProbe{
+						LifecycleActionHandler: appsv1alpha1.LifecycleActionHandler{
+							BuiltinHandler: &handler,
+						},
+					},
+				},
+			},
+		}
+		if !op.memberJoinEnabled() {
+			t.Fatal("expected member join to be enabled for MongoDB role probe builtin")
+		}
+	})
+
+	t.Run("non-mongodb without member join", func(t *testing.T) {
+		op := &componentWorkloadOps{
+			synthesizeComp: &component.SynthesizedComponent{
+				CharacterType: constant.MySQLCharacterType,
+			},
+		}
+		if op.memberJoinEnabled() {
+			t.Fatal("expected member join to be disabled")
+		}
+	})
+
+	t.Run("mongodb missing role probe builtin", func(t *testing.T) {
+		op := &componentWorkloadOps{
+			synthesizeComp: &component.SynthesizedComponent{
+				CharacterType: constant.MongoDBCharacterType,
+				LifecycleActions: &appsv1alpha1.ComponentLifecycleActions{
+					RoleProbe: &appsv1alpha1.RoleProbe{},
+				},
+			},
+		}
+		if op.memberJoinEnabled() {
+			t.Fatal("expected member join to be disabled without MongoDB builtin role probe")
+		}
+	})
+}
+
+func TestDetectPodsToMemberJoin(t *testing.T) {
+	t.Run("no leader present", func(t *testing.T) {
+		op := newMemberJoinOps(3, []workloads.MemberStatus{{PodName: "pod-0"}}, "pod-0", "pod-1")
+		pods := []*corev1.Pod{newTestPod("pod-1", corev1.PodRunning, true)}
+		if got := op.detectPodsToMemberJoin(pods); got.Len() != 0 {
+			t.Fatalf("expected no pods to join, got %v", sets.List(got))
+		}
+	})
+
+	t.Run("replicas already satisfied", func(t *testing.T) {
+		op := newMemberJoinOps(1, []workloads.MemberStatus{{
+			PodName:     "pod-0",
+			ReplicaRole: &workloads.ReplicaRole{IsLeader: true},
+		}}, "pod-0", "pod-1")
+		pods := []*corev1.Pod{newTestPod("pod-1", corev1.PodRunning, true)}
+		if got := op.detectPodsToMemberJoin(pods); got.Len() != 0 {
+			t.Fatalf("expected no pods to join, got %v", sets.List(got))
+		}
+	})
+
+	t.Run("filters pod states and labels", func(t *testing.T) {
+		op := newMemberJoinOps(3, []workloads.MemberStatus{{
+			PodName:     "pod-0",
+			ReplicaRole: &workloads.ReplicaRole{IsLeader: true},
+		}}, "pod-0", "pod-1", "pod-2", "pod-3", "pod-4", "pod-5")
+
+		pod0 := newTestPod("pod-0", corev1.PodRunning, true)
+		pod1 := newTestPod("pod-1", corev1.PodRunning, true)
+		pod2 := newTestPod("pod-2", corev1.PodRunning, false)
+		pod3 := newTestPod("pod-3", corev1.PodPending, false)
+		pod4 := newTestPod("pod-4", corev1.PodRunning, true)
+		pod4.Labels = map[string]string{constant.RoleLabelKey: "leader"}
+		pod5 := newTestPod("pod-5", corev1.PodRunning, true)
+		ts := metav1.NewTime(time.Now())
+		pod5.DeletionTimestamp = &ts
+		podX := newTestPod("pod-x", corev1.PodRunning, true)
+
+		got := op.detectPodsToMemberJoin([]*corev1.Pod{pod0, pod1, pod2, pod3, pod4, pod5, podX})
+		if got.Len() != 2 || !got.Has("pod-1") || !got.Has("pod-2") {
+			t.Fatalf("unexpected pods to join: %v", sets.List(got))
+		}
+		if got.Has("pod-3") || got.Has("pod-4") || got.Has("pod-5") {
+			t.Fatalf("unexpected pods included: %v", sets.List(got))
+		}
+	})
+}
+
+func newMemberJoinOps(replicas int32, members []workloads.MemberStatus, desired ...string) *componentWorkloadOps {
+	return &componentWorkloadOps{
+		runningITS: &workloads.InstanceSet{
+			Spec: workloads.InstanceSetSpec{Replicas: int32Ptr(replicas)},
+			Status: workloads.InstanceSetStatus{
+				MembersStatus: members,
+			},
+		},
+		desiredCompPodNameSet: sets.New[string](desired...),
+	}
+}
+
+func newTestPod(name string, phase corev1.PodPhase, ready bool) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: corev1.PodStatus{
+			Phase: phase,
+		},
+	}
+	if ready {
+		pod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}
+	}
+	return pod
+}
+
+func int32Ptr(value int32) *int32 {
+	return &value
+}


### PR DESCRIPTION
Issue:
  After directly updating Cluster replicas, MongoDB keeps only the primary; secondaries never join. Pods are Running but have no role label and the component stays Updating.

  Root Cause:
  memberJoin is triggered only via annotation; when scale-out is bypassed and ClusterDefinition doesn’t define memberJoin, join never runs. The detection was also too strict (Ready-only), creating a deadlock.

  Fix:
  1) Auto-detect pods that should join when the annotation is empty
  2) For MongoDB, allow join even if lifecycleActions.memberJoin is not defined
  3) Relax detection to include Running pods
  4) Allow doMemberJoin to execute without explicit memberJoin config for MongoDB

  Impact:
  Limited to MongoDB components (CharacterType=mongodb with roleProbe builtinHandler=mongodb). Other engines are unaffected.

  Code:
  controllers/apps/transformer_component_workload.go

  Verification:
  Trigger reconcile, confirm controller logs show “detected pods to member join”, and validate pod role labels + rs.status members are complete.

  Tests:
  Not run (manual verification via reconcile + role labels + rs.status).

  If you want, I can also provide a shorter “summary + test plan” version.