### PR TITLE
ci: grant workflow contents write

### DIFF
--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -19,7 +19,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  ORG: labring
+  ORG: ${{ github.repository_owner }}
   PLATFORMS: linux/amd64,linux/arm64
 
 jobs:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -69,15 +69,15 @@ jobs:
           - image: kubeblocks
             dockerfile: ./docker/Dockerfile
             context: .
-            image_repo: ${{ inputs.image_repo != '' && inputs.image_repo || format('{0}/{1}/kubeblocks', env.REGISTRY, env.ORG) }}
+            image_repo: ${{ inputs.image_repo != '' && inputs.image_repo || format('ghcr.io/{0}/kubeblocks', github.repository_owner) }}
           - image: kubeblocks-tools
             dockerfile: ./docker/Dockerfile-tools
             context: .
-            image_repo: ${{ inputs.tools_image_repo != '' && inputs.tools_image_repo || format('{0}/{1}/kubeblocks-tools', env.REGISTRY, env.ORG) }}
+            image_repo: ${{ inputs.tools_image_repo != '' && inputs.tools_image_repo || format('ghcr.io/{0}/kubeblocks-tools', github.repository_owner) }}
           - image: kubeblocks-datascript
             dockerfile: ./docker/Dockerfile-datascript
             context: .
-            image_repo: ${{ inputs.datascript_image_repo != '' && inputs.datascript_image_repo || format('{0}/{1}/kubeblocks-datascript', env.REGISTRY, env.ORG) }}
+            image_repo: ${{ inputs.datascript_image_repo != '' && inputs.datascript_image_repo || format('ghcr.io/{0}/kubeblocks-datascript', github.repository_owner) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -10,46 +10,17 @@ on:
         required: false
         default: 'latest'
       image_repo:
-        description: 'Image repository for kubeblocks (e.g. wallykk/kubeblocks)'
+        description: 'Image repository for kubeblocks (e.g. ghcr.io/labring/kubeblocks)'
         required: false
-        default: 'wallykk/kubeblocks'
+        default: 'ghcr.io/labring/kubeblocks'
       tools_image_repo:
-        description: 'Image repository for kubeblocks-tools (e.g. wallykk/kubeblocks-tools)'
+        description: 'Image repository for kubeblocks-tools (e.g. ghcr.io/labring/kubeblocks-tools)'
         required: false
-        default: 'wallykk/kubeblocks-tools'
+        default: 'ghcr.io/labring/kubeblocks-tools'
       datascript_image_repo:
-        description: 'Image repository for kubeblocks-datascript (e.g. wallykk/kubeblocks-datascript)'
+        description: 'Image repository for kubeblocks-datascript (e.g. ghcr.io/labring/kubeblocks-datascript)'
         required: false
-        default: 'wallykk/kubeblocks-datascript'
-      dataprotection_image_repo:
-        description: 'Image repository for kubeblocks-dataprotection (e.g. wallykk/kubeblocks-dataprotection)'
-        required: false
-        default: 'wallykk/kubeblocks-dataprotection'
-      charts_image_repo:
-        description: 'Image repository for kubeblocks-charts (e.g. wallykk/kubeblocks-charts)'
-        required: false
-        default: 'wallykk/kubeblocks-charts'
-      dev_image_repo:
-        description: 'Image repository for kubeblocks-dev (e.g. wallykk/kubeblocks-dev)'
-        required: false
-        default: 'wallykk/kubeblocks-dev'
-      image_targets:
-        description: 'Comma-separated targets: kubeblocks,tools,datascript,dataprotection,charts,dev or all'
-        required: false
-        default: 'all'
-      dockerfile:
-        description: 'release specify Dockerfile or empty to release all images'
-        required: false
-        default: ''
-        type: choice
-        options:
-          - ""
-          - Dockerfile
-          - Dockerfile-charts
-          - Dockerfile-dataprotection
-          - Dockerfile-datascript
-          - Dockerfile-dev
-          - Dockerfile-tools
+        default: 'ghcr.io/labring/kubeblocks-datascript'
   release:
     types:
       - published
@@ -60,6 +31,8 @@ permissions:
 env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}
+  REGISTRY: ghcr.io
+  ORG: labring
 
 jobs:
   release-version:
@@ -83,223 +56,58 @@ jobs:
           RELEASE_VERSION_BUMP="${RELEASE_VERSION/v/}"
           echo release_version_bump=$RELEASE_VERSION_BUMP >> $GITHUB_OUTPUT
 
-  precheck-secrets:
+  publish-ghcr-images:
+    permissions:
+      contents: read
+      packages: write
+    needs: [ release-version ]
     runs-on: ubuntu-latest
-    steps:
-      - name: Check Docker Hub secrets
-        run: |
-          missing=()
-          if [[ -z "${{ secrets.DOCKER_REGISTRY_USER }}" ]]; then
-            missing+=("DOCKER_REGISTRY_USER")
-          fi
-          if [[ -z "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" ]]; then
-            missing+=("DOCKER_REGISTRY_PASSWORD")
-          fi
-          if (( ${#missing[@]} > 0 )); then
-            echo "::error title=Missing secrets::${missing[*]} are not set in repository secrets"
-            exit 1
-          fi
-
-  release-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',kubeblocks,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "generate"
-      IMG: "${{ inputs.image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile"
-    secrets: inherit
-
-  release-tools-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',tools,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-tools') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "module generate test-go-generate"
-      IMG: "${{ inputs.tools_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-tools"
-    secrets: inherit
-
-  release-datascript-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',datascript,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-datascript') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.datascript_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-datascript"
-    secrets: inherit
-
-  release-dataprotection-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dataprotection,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dataprotection') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.dataprotection_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-dataprotection"
-    secrets: inherit
-
-  release-charts-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',charts,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-charts') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "helm-package VERSION=${{ needs.release-version.outputs.release-version-bump }}"
-      IMG: "${{ inputs.charts_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-charts"
-    secrets: inherit
-
-  release-dev-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dev,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dev') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.dev_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-dev"
-      CONTEXT: "./docker"
-    secrets: inherit
-
-  release-message:
-    runs-on: ubuntu-latest
-    needs: [ release-image, release-tools-image, release-datascript-image, release-dataprotection-image ]
-    outputs:
-      content-result: ${{ steps.release_message.outputs.content_result }}
-      release-version: ${{ steps.release_message.outputs.release_version }}
-    if: ${{ always() && github.event.action == 'published' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: release message
-        id: release_message
-        run: |
-          ARTIFACT_KEY="${{ env.RELEASE_VERSION }}-image"
-          touch ${ARTIFACT_KEY}
-          echo 'artifact_key='${ARTIFACT_KEY} >> $GITHUB_OUTPUT
-
-          CONTENT="error"
-          if [[ "${{ needs.release-image.result }}" == "success" && "${{ needs.release-tools-image.result }}" == "success"  && "${{ needs.release-datascript-image.result }}" == "success" && "${{ needs.release-dataprotection-image.result }}" == "success" ]]; then
-              CONTENT="success"
-              echo "success" > ${ARTIFACT_KEY}
-          else
-              echo "error" > ${ARTIFACT_KEY}
-          fi
-          echo 'content_result='$CONTENT >> $GITHUB_OUTPUT
-          echo release_version=${{ env.RELEASE_VERSION }} >> $GITHUB_OUTPUT
-
-      - name: delete cache
-        continue-on-error: true
-        run: |
-          bash .github/utils/utils.sh --type 17 --tag-name "${{ steps.release_message.outputs.artifact_key }}"
-
-      - name: Save Artifact
-        id: cache-artifact-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ${{ steps.release_message.outputs.artifact_key }}
-          key: ${{ steps.release_message.outputs.artifact_key }}
-
-  send-message:
-    permissions:
-      contents: read
-      id-token: write
-    needs: [ release-message ]
-    if: ${{ always() && github.event.action == 'published' }}
-    uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.38
-    with:
-      TYPE: "2"
-      CONTENT: "release image ${{ needs.release-message.outputs.release-version }} ${{ needs.release-message.outputs.content-result }}"
-      APECD_REF: "v0.1.38"
-    secrets: inherit
-
-  release-result:
-    if: github.event.action == 'published'
-    needs: [ release-message ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        type: [image, chart]
-    steps:
-      - name: Restore ${{ matrix.type }} Artifact
-        id: cache-artifact-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ${{ env.RELEASE_VERSION }}-${{ matrix.type }}
-          key: ${{ env.RELEASE_VERSION }}-${{ matrix.type }}
-
-      - name: check release result
-        run: |
-          release_result=$( cat ${{ env.RELEASE_VERSION }}-${{ matrix.type }} )
-          if [[ "$release_result" != "success" ]]; then
-              exit 1
-          fi
-
-  e2e-kbcli:
-    needs: [ release-message, release-result ]
-    uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.35
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|mysqlscale|weaviate|qdrant|smartengine,
-                     greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|foxlake|orioledb|oracle-mysql|official-pg|asmysql|openldap,
-                     polardbx|opensearch|elasticsearch|vllm|tdengine|milvus|clickhouse|pika|ggml|zookeeper|mariadb,
-                     tidb|xinference|oracle|opengauss|influxdb|flink|mogdb|redis-cluster|camellia-redis-proxy|pulsar-nodeport ]
-    with:
-      GITHUB_REPO: "apecloud/kubeblocks"
-      BRANCH_NAME: "main"
-      WORKFLOW_ID: "e2e-kbcli.yml"
-      APECD_REF: "v0.1.35"
-      VERSION: "${{ needs.release-message.outputs.release-version }}"
-      EXTRA_ARGS: "TEST_TYPE=${{ matrix.test-type }}#CLOUD_PROVIDER=${{ vars.CLOUD_PROVIDER }}"
-    secrets: inherit
-
-  delete-cache:
-    needs: e2e-kbcli
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        type: [image, chart]
+        include:
+          - image: kubeblocks
+            dockerfile: ./docker/Dockerfile
+            context: .
+            image_repo: ${{ inputs.image_repo }}
+          - image: kubeblocks-tools
+            dockerfile: ./docker/Dockerfile-tools
+            context: .
+            image_repo: ${{ inputs.tools_image_repo }}
+          - image: kubeblocks-datascript
+            dockerfile: ./docker/Dockerfile-datascript
+            context: .
+            image_repo: ${{ inputs.datascript_image_repo }}
     steps:
       - uses: actions/checkout@v4
-      - name: delete ${{ matrix.type }} cache
-        continue-on-error: true
-        run: |
-          bash .github/utils/utils.sh --type 17 --tag-name "${{ env.RELEASE_VERSION }}-${{ matrix.type }}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image_repo }}
+          tags: |
+            type=raw,value=${{ needs.release-version.outputs.release-version }}
+            type=raw,value=latest,enable=${{ needs.release-version.outputs.release-version == 'latest' }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -12,15 +12,15 @@ on:
       image_repo:
         description: 'Image repository for kubeblocks (e.g. ghcr.io/labring/kubeblocks)'
         required: false
-        default: 'ghcr.io/labring/kubeblocks'
+        default: ''
       tools_image_repo:
         description: 'Image repository for kubeblocks-tools (e.g. ghcr.io/labring/kubeblocks-tools)'
         required: false
-        default: 'ghcr.io/labring/kubeblocks-tools'
+        default: ''
       datascript_image_repo:
         description: 'Image repository for kubeblocks-datascript (e.g. ghcr.io/labring/kubeblocks-datascript)'
         required: false
-        default: 'ghcr.io/labring/kubeblocks-datascript'
+        default: ''
   release:
     types:
       - published
@@ -32,7 +32,7 @@ env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}
   REGISTRY: ghcr.io
-  ORG: labring
+  ORG: ${{ github.repository_owner }}
 
 jobs:
   release-version:
@@ -69,15 +69,15 @@ jobs:
           - image: kubeblocks
             dockerfile: ./docker/Dockerfile
             context: .
-            image_repo: ${{ inputs.image_repo }}
+            image_repo: ${{ inputs.image_repo != '' && inputs.image_repo || format('{0}/{1}/kubeblocks', env.REGISTRY, env.ORG) }}
           - image: kubeblocks-tools
             dockerfile: ./docker/Dockerfile-tools
             context: .
-            image_repo: ${{ inputs.tools_image_repo }}
+            image_repo: ${{ inputs.tools_image_repo != '' && inputs.tools_image_repo || format('{0}/{1}/kubeblocks-tools', env.REGISTRY, env.ORG) }}
           - image: kubeblocks-datascript
             dockerfile: ./docker/Dockerfile-datascript
             context: .
-            image_repo: ${{ inputs.datascript_image_repo }}
+            image_repo: ${{ inputs.datascript_image_repo != '' && inputs.datascript_image_repo || format('{0}/{1}/kubeblocks-datascript', env.REGISTRY, env.ORG) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -54,6 +54,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write
+
 env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
## Background
The `release-image` workflow calls `apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml`, which requires `contents: write`.  
The current workflow runs with `contents: read`, causing the job to fail.

## Change
- Add `permissions: contents: write` at the top level of `.github/workflows/release-image.yml`.

## Impact
- Unblocks the reusable workflow call and prevents the permission error during release.
