### PR TITLE
feat: multiarch release for 0.9.3

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,10 +1,7 @@
-name: Cherry Pick
+name: CHERRY-PICK
 on:
   issue_comment:
     types: [created]
-
-env:
-  GH_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
 
 jobs:
@@ -15,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Automatic Cherry Pick
         uses: apecloud-inc/gha-cherry-pick@v1
         env:
-          GITHUB_TOKEN: ${{ env.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -1,26 +1,22 @@
-name: Pull Request
+name: CICD-PULL-REQUEST
 
 on:
-  pull_request:
-    types: [ labeled ]
-    branches:
-      - main
-      - release-*
+  pull_request_review:
+    types: [submitted]
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  BASE_BRANCH: origin/main
+  BASE_BRANCH: origin/${{ github.event.pull_request.base.ref }}
   GO_VERSION: "1.21"
 
 jobs:
   trigger-mode:
     name: trigger mode
-    if: github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'pre-approve')
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     outputs:
       trigger-mode: ${{ steps.get_trigger_mode.outputs.trigger_mode }}
-      git-commit: ${{ steps.get_git_info.outputs.git_commit }}
-      git-version: ${{ steps.get_git_info.outputs.git_version }}
+      matrix: ${{ steps.get_trigger_mode.outputs.matrix }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -35,39 +31,37 @@ jobs:
 
       - name: Get trigger mode
         id: get_trigger_mode
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          if [[ "${HEAD_REF}" != "main" ]]; then
-              git checkout -b ${HEAD_REF} --track origin/${HEAD_REF}
+          if [[ "${{ github.event.pull_request.head.ref }}" != "main" ]]; then
+              git checkout -b ${{ github.event.pull_request.head.ref }} --track origin/${{ github.event.pull_request.head.ref }}
           fi
           TRIGGER_MODE=`bash .github/utils/utils.sh --type 6 \
-              --branch-name "${HEAD_REF}" \
+              --branch-name "${{ github.event.pull_request.head.ref }}" \
               --base-branch "${{ env.BASE_BRANCH }}"`
           echo $TRIGGER_MODE
           echo trigger_mode=$TRIGGER_MODE >> $GITHUB_OUTPUT
 
-      - name: get git info
-        id: get_git_info
-        run: |
-          GIT_COMMIT=$(git rev-list -1 HEAD)
-          GIT_VERSION=$(git describe --always --abbrev=0 --tag)
-          echo git_commit=$GIT_COMMIT >> $GITHUB_OUTPUT
-          echo git_version=$GIT_VERSION >> $GITHUB_OUTPUT
+          TEST_PACKAGES=`bash .github/utils/utils.sh --type 16 \
+              --trigger-type "$TRIGGER_MODE" \
+              --test-pkgs "${{ vars.TEST_PKGS }}" \
+              --test-check "${{ vars.TEST_CHECK }}" \
+              --test-pkgs-first "${{ vars.TEST_PKGS_FIRST }}" \
+              --ignore-pkgs "${{ vars.SKIP_CHECK_PKG }}"`
+          echo "$TEST_PACKAGES"
+          echo "matrix={\"include\":[$TEST_PACKAGES]}" >> $GITHUB_OUTPUT
 
-  pr-pre-check:
+  test-parallel:
+    name: test
     needs: trigger-mode
-    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') }}
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        ops: [ 'manifests', 'mod-vendor', 'generate', 'lint', 'staticcheck', 'test' ]
+      matrix: ${{ fromJSON(needs.trigger-mode.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - name: install lib
         run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libbtrfs-dev \
@@ -81,27 +75,47 @@ jobs:
       - name: Install golangci-lint
         if: matrix.ops == 'lint'
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
 
       - name: make ${{ matrix.ops }}
+        if: ${{ ! contains(matrix.ops, '/') }}
         run: |
           make ${{ matrix.ops }}
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          if [[ ("${{ matrix.ops }}" == 'generate' || "${{ matrix.ops }}" == 'manifests') && -n "$FILE_CHANGES" ]]; then
-              echo $FILE_CHANGES
-              echo "make "${{ matrix.ops }}" causes inconsistent files"
-              exit 1
+
+      - name: make test ${{ matrix.ops }}
+        if: ${{ contains(matrix.ops, '/') }}
+        run: |
+          if [[ -d "./${{ matrix.ops }}" ]]; then
+              make test TEST_PACKAGES=./${{ matrix.ops }}/...
           fi
 
+  make-test:
+    needs: trigger-mode
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') && github.event.pull_request.head.repo.full_name != github.repository }}
+    outputs:
+      runner-name: ${{ steps.get_runner_name.outputs.runner_name }}
+    runs-on: [ self-hosted, gke-runner-go1.21 ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: make mod-vendor
+        run: |
+          make mod-vendor
+
+      - name: make lint
+        run: |
+          make lint
+
+      - name: make test
+        run: |
+          make test
+
       - name: ignore cover pkgs
-        if: matrix.ops == 'test'
         run: |
           bash .github/utils/utils.sh --type 14 \
               --file cover.out \
               --ignore-pkgs "${{ vars.IGNORE_COVERAGE_PKG }}"
 
       - name: upload coverage report
-        if: matrix.ops == 'test'
         uses: codecov/codecov-action@v3
         continue-on-error: true
         with:
@@ -111,23 +125,44 @@ jobs:
           name: codecov-report
           verbose: true
 
+      - name: kill kube-apiserver and etcd
+        id: get_runner_name
+        if: ${{ always() }}
+        run: |
+          echo runner_name=${RUNNER_NAME} >> $GITHUB_OUTPUT
+          bash .github/utils/utils.sh --type 8
+
+  remove-runner:
+    needs: [ trigger-mode, make-test ]
+    runs-on: ubuntu-latest
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') && github.event.pull_request.head.repo.full_name != github.repository && always()  }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: remove runner
+        run: |
+          bash .github/utils/utils.sh --type 9 \
+              --github-token ${{ env.GITHUB_TOKEN }} \
+              --runner-name ${{ needs.make-test.outputs.runner-name }}
+
   check-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[docker]')
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.64
+    uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
     with:
       MAKE_OPS_PRE: "generate"
       IMG: "apecloud/kubeblocks"
       GO_VERSION: "1.21"
       BUILDX_PLATFORMS: "linux/amd64"
       DOCKERFILE_PATH: "./docker/Dockerfile"
-      BUILDX_ARGS: |
-        VERSION=${{ needs.trigger-mode.outputs.git-version }}
-        GIT_COMMIT=${{ needs.trigger-mode.outputs.git-commit }}
-        GIT_VERSION=${{ needs.trigger-mode.outputs.git-version }}
     secrets: inherit
 
   check-tools-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[docker]')
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -140,6 +175,9 @@ jobs:
     secrets: inherit
 
   check-datascript-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[docker]')
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -150,6 +188,9 @@ jobs:
     secrets: inherit
 
   check-dataprotection-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[docker]')
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -176,13 +217,22 @@ jobs:
 
   pr-check:
     name: make test
-    needs: [ trigger-mode, pr-pre-check, check-image, check-tools-image, check-datascript-image, check-dataprotection-image, check-helm ]
-    if: ${{ github.event.action == 'labeled' && (github.event.label.name == 'approved' || github.event.label.name == 'pre-approve') && always() }}
+    needs: [ trigger-mode, test-parallel, make-test, check-image, check-tools-image, check-datascript-image, check-dataprotection-image, check-helm ]
+    if: ${{ github.event.review.state == 'approved' && always() }}
     runs-on: ubuntu-latest
     steps:
-      - name: pr pre check
+      - name: test parallel check
+        if: github.event.pull_request.head.repo.full_name == github.repository
         run: |
-          if [[ "${{ needs.pr-pre-check.result }}" == "failure" || "${{ needs.pr-pre-check.result }}" == "cancelled" ]]; then
+          if [[ "${{ needs.test-parallel.result }}" == "failure" || "${{ needs.test-parallel.result }}" == "cancelled" ]]; then
+              echo "test parallel fail"
+              exit 1
+          fi
+
+      - name: make test check
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          if [[ "${{ needs.make-test.result }}" == "failure" || "${{ needs.make-test.result }}" == "cancelled" ]]; then
               echo "make test fail"
               exit 1
           fi

--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -1,15 +1,16 @@
-name: CICD Push
+name: CICD-PUSH
 
 on:
   push:
     branches:
-      - '**'
+      - '*'
+      - '*/*'
     tags-ignore:
-      - '**'
+      - '*'
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  BASE_BRANCH: origin/main
+  BASE_BRANCH: origin/${{ github.event.repository.default_branch }}
   GO_VERSION: "1.21"
 
 jobs:
@@ -18,8 +19,6 @@ jobs:
     outputs:
       trigger-mode: ${{ steps.get_trigger_mode.outputs.trigger_mode }}
       base-commitid: ${{ steps.get_trigger_mode.outputs.base_commitid }}
-      git-commit: ${{ steps.get_git_info.outputs.git_commit }}
-      git-version: ${{ steps.get_git_info.outputs.git_version }}
     steps:
       - name: Cancel Previous Runs
         if: github.ref_name != 'main'
@@ -47,14 +46,6 @@ jobs:
           echo trigger_mode=$TRIGGER_MODE >> $GITHUB_OUTPUT
           echo base_commitid=$BASE_COMMITID >> $GITHUB_OUTPUT
 
-      - name: get git info
-        id: get_git_info
-        run: |
-          GIT_COMMIT=$(git rev-list -1 HEAD)
-          GIT_VERSION=$(git describe --always --abbrev=0 --tag)
-          echo git_commit=$GIT_COMMIT >> $GITHUB_OUTPUT
-          echo git_version=$GIT_VERSION >> $GITHUB_OUTPUT
-
       - name: merge releasing to release
         if: ${{ startsWith(github.ref_name, 'releasing-') }}
         run: |
@@ -72,7 +63,6 @@ jobs:
           fetch-depth: 0
       - name: install pcregrep
         run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install pcregrep
 
@@ -82,7 +72,7 @@ jobs:
           echo "FILE_PATH: $FILE_PATH"
           for filePath in $(echo "$FILE_PATH"); do
               filePath="${filePath%/*}"
-              if [[ -d $filePath && "$filePath" != *"i18n/zh-cn"* ]]; then
+              if [[ -d $filePath ]]; then
                   echo $(pcregrep -r -n -I '[^\x00-\x7f]' $filePath >> pcregrep.out)
               fi
           done
@@ -98,53 +88,47 @@ jobs:
           files: docs/
           config: .github/utils/typos.toml
 
-  push-pre-check:
+  make-test:
     needs: trigger-mode
+    runs-on: [self-hosted, gke-runner-go1.21]
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[test]')
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        ops: [ 'manifests', 'mod-vendor', 'generate', 'lint', 'staticcheck', 'test' ]
+    outputs:
+      runner-name: ${{ steps.get_runner_name.outputs.runner_name }}
     steps:
       - uses: actions/checkout@v4
-      - name: install lib
+      - name: make manifests check
         run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libbtrfs-dev \
-            libdevmapper-dev
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-
-      - name: Install golangci-lint
-        if: matrix.ops == 'lint'
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
-
-      - name: make ${{ matrix.ops }}
-        run: |
-          make ${{ matrix.ops }}
+          make manifests
           FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          if [[ ("${{ matrix.ops }}" == 'generate' || "${{ matrix.ops }}" == 'manifests') && -n "$FILE_CHANGES" ]]; then
-              echo $FILE_CHANGES
-              echo "make "${{ matrix.ops }}" causes inconsistent files"
-              exit 1
+          if [[ ! -z "$FILE_CHANGES" ]]; then
+            echo $FILE_CHANGES
+            echo "make manifests causes inconsistent files"
+            exit 1
           fi
 
+      - name: make mod-vendor
+        run: |
+          make mod-vendor
+
+      - name: make staticcheck
+        run: |
+          make staticcheck
+
+      - name: make lint
+        run: |
+          make lint
+
+      - name: make test
+        run: |
+          make test
+
       - name: ignore cover pkgs
-        if: matrix.ops == 'test'
         run: |
           bash .github/utils/utils.sh --type 14 \
               --file cover.out \
               --ignore-pkgs "${{ vars.IGNORE_COVERAGE_PKG }}"
 
       - name: upload coverage report
-        if: matrix.ops == 'test'
         uses: codecov/codecov-action@v3
         continue-on-error: true
         with:
@@ -154,23 +138,44 @@ jobs:
           name: codecov-report
           verbose: true
 
+      - name: kill kube-apiserver and etcd
+        id: get_runner_name
+        if: ${{ always() }}
+        run: |
+          echo runner_name=${RUNNER_NAME} >> $GITHUB_OUTPUT
+          bash .github/utils/utils.sh --type 8
+
+  remove-runner:
+    needs: [ trigger-mode, make-test ]
+    runs-on: ubuntu-latest
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') && always() }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: remove runner
+        run: |
+          bash .github/utils/utils.sh --type 9 \
+            --github-token "${{ env.GITHUB_TOKEN }}" \
+            --runner-name ${{ needs.make-test.outputs.runner-name }}
+
   check-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[docker]') }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.64
+    uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
     with:
       MAKE_OPS_PRE: "generate"
       IMG: "apecloud/kubeblocks"
       GO_VERSION: "1.21"
       BUILDX_PLATFORMS: "linux/amd64"
       DOCKERFILE_PATH: "./docker/Dockerfile"
-      BUILDX_ARGS: |
-        VERSION=${{ needs.trigger-mode.outputs.git-version }}
-        GIT_COMMIT=${{ needs.trigger-mode.outputs.git-commit }}
-        GIT_VERSION=${{ needs.trigger-mode.outputs.git-version }}
     secrets: inherit
 
   check-tools-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[docker]') }}
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -183,6 +188,9 @@ jobs:
     secrets: inherit
 
   check-datascript-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[docker]') }}
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -193,6 +201,9 @@ jobs:
     secrets: inherit
 
   check-dataprotection-image:
+    permissions:
+      contents: read
+      id-token: write
     needs: trigger-mode
     if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[docker]') }}
     uses: apecloud/apecloud-cd/.github/workflows/release-image-check.yml@v0.1.24
@@ -237,96 +248,3 @@ jobs:
       WORKFLOW_ID: "deploy.yml"
       APECD_REF: "v0.1.43"
     secrets: inherit
-
-  apis-doc:
-    needs: [ trigger-mode ]
-    runs-on: ubuntu-latest
-    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[apis]') || contains(needs.trigger-mode.outputs.trigger-mode, '[lorry]') }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: install lib
-        run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libbtrfs-dev \
-            libdevmapper-dev
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-
-      - name: Check apis doc
-        run: |
-          make doc
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          if [[ ! -z "$FILE_CHANGES" ]]; then
-            echo $FILE_CHANGES
-            echo "make doc causes apis doc changes"
-            exit 1
-          fi
-
-  check-license-header:
-    needs: [ trigger-mode ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: check license-header
-        run: |
-          check_lh_ret=$(make check-license-header | (grep 'FAIL' || true) )
-          if [[ -n "$check_lh_ret" ]]; then
-            echo "$check_lh_ret"
-            echo "check license-header FAIL"
-            exit 1
-          fi
-
-  push-check:
-    name: make-test
-    needs: [ trigger-mode, push-pre-check, check-image, check-tools-image,
-             check-datascript-image, check-dataprotection-image, check-helm, apis-doc, check-license-header ]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: push pre check
-        run: |
-          if [[ "${{ needs.push-pre-check.result }}" == "failure" || "${{ needs.push-pre-check.result }}" == "cancelled" ]]; then
-              echo "push pre check fail"
-              exit 1
-          fi
-
-      - name: release image check
-        run: |
-          if [[ "${{ needs.check-image.result }}" == "failure" || "${{ needs.check-image.result }}" == "cancelled" ]]; then
-              echo "check kubeblocks image fail"
-              exit 1
-          fi
-
-          if [[ "${{ needs.check-tools-image.result }}" == "failure" || "${{ needs.check-tools-image.result }}" == "cancelled" ]]; then
-              echo "check tools image fail"
-              exit 1
-          fi
-
-          if [[ "${{ needs.check-datascript-image.result }}" == "failure" || "${{ needs.check-datascript-image.result }}" == "cancelled" ]]; then
-              echo "check datascript image fail"
-              exit 1
-          fi
-
-          if [[ "${{ needs.check-dataprotection-image.result }}" == "failure" || "${{ needs.check-dataprotection-image.result }}" == "cancelled" ]]; then
-              echo "check dataprotection image fail"
-              exit 1
-          fi
-
-      - name: apis doc check
-        run: |
-          if [[ "${{ needs.check-license-header.result }}" == "failure" || "${{ needs.check-license-header.result }}" == "cancelled" ]]; then
-              echo "check apis doc fail"
-              exit 1
-          fi
-
-      - name: license header check
-        run: |
-          if [[ "${{ needs.check-license-header.result }}" == "failure" || "${{ needs.check-license-header.result }}" == "cancelled" ]]; then
-              echo "check license header fail"
-              exit 1
-          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,7 +53,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: install lib
         run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libbtrfs-dev \

--- a/.github/workflows/e2e-fault.yml
+++ b/.github/workflows/e2e-fault.yml
@@ -1,4 +1,4 @@
-name: Test E2E Fault
+name: E2E Fault Test
 
 on:
   workflow_dispatch:
@@ -20,13 +20,11 @@ on:
           - gke
           - eks
       CLUSTER_VERSION:
-        description: 'k8s cluster version'
+        description: 'k8s cluster version (e.g. 1.26)'
         required: false
-        default: '1.27'
+        default: '1.26'
         type: choice
         options:
-          - 1.29
-          - 1.28
           - 1.27
           - 1.26
           - 1.25
@@ -78,7 +76,7 @@ jobs:
           if [[ "${{ inputs.CLOUD_PROVIDER }}" == 'eks' && -z "$CLUSTER_REGION" ]]; then
               CLUSTER_REGION="${{ vars.REGION_AWS_EKS }}"
           elif [[ "${{ inputs.CLOUD_PROVIDER }}" == 'gke' && -z "$CLUSTER_REGION" ]]; then
-              CLUSTER_REGION="${{ vars.REGION_GCP_GKE }}"
+              CLUSTER_REGION="${{ vars.REGION_GCP_GEK }}"
           fi
           echo cluster-region=$CLUSTER_REGION >> $GITHUB_OUTPUT
 

--- a/.github/workflows/e2e-kbcli-k3s.yml
+++ b/.github/workflows/e2e-kbcli-k3s.yml
@@ -12,28 +12,22 @@ on:
         required: false
         default: ''
       TEST_TYPE:
-        description: 'test type (e.g. apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|mysqlscale|weaviate|qdrant|smartengine|
-        greptimedb|nebula|risingwave|starrocks|etcd|foxlake|orioledb|oracle-mysql|vanilla-pg|asmysql|openldap|polardbx|
-        opensearch|elasticsearch|vllm|tdengine|milvus|clickhouse|pika|ggml|zookeeper|mariadb|tidb|xinference|
-        oracle|opengauss|influxdb|flink|solr|doris|halo|mogdb|starrocks-ent|apecloud-postgresql|yashandb|redis-cluster|camellia-redis-proxy|dmdb|minio)'
+        description: 'test type (e.g. apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|weaviate|qdrant|
+        smartengine|mysqlscale|greptimedb|nebula|risingwave|starrocks|etcd|foxlake|oracle-mysql|asmysql|
+        openldap|milvus|clickhouse|pika|opensearch|elasticsearch|tdengine|vllm|orioledb|official-pg|ggml|
+        zookeeper|mariadb|tidb|xinference|oracle|opengauss|influxdb)'
         required: false
         default: ''
       CLUSTER_VERSION:
-        description: 'k8s cluster version'
+        description: 'k8s cluster version (e.g. 1.26)'
         required: false
-        default: '1.27'
+        default: '1.26'
         type: choice
         options:
-          - "1.29"
-          - "1.28"
-          - "1.27"
-          - "1.26"
-          - "1.25"
-          - "1.24"
-          - "1.23"
-          - "1.22"
-          - "1.21"
-          - "1.20"
+          - 1.27
+          - 1.26
+          - 1.25
+          - 1.24
       BRANCH_NAME:
         description: 'testinfra branch name'
         required: false

--- a/.github/workflows/e2e-kbcli.yml
+++ b/.github/workflows/e2e-kbcli.yml
@@ -12,12 +12,10 @@ on:
         required: false
         default: ''
       TEST_TYPE:
-        description: 'test type (e.g.  apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|mysqlscale|weaviate|qdrant|
-        smartengine|greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|foxlake|orioledb|vanilla-pg|asmysql|openldap|
-        polardbx|opensearch|elasticsearch|vllm|tdengine|milvus|clickhouse|pika|ggml|zookeeper|mariadb|tidb|xinference|
-        oracle|opengauss|influxdb|flink|solr|mogdb|oceanbase-ent|starrocks-ent|apecloud-postgresql|yashandb|
-        redis-cluster|camellia-redis-proxy|dmdb|minio|orchestrator|rabbitmq|loki|victoria-metrics|gaussdb|damengdb|
-        kingbase|vastbase|mssql|rocketmq)'
+        description: 'test type (e.g. apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|weaviate|qdrant|
+        smartengine|mysqlscale|greptimedb|nebula|risingwave|starrocks|etcd|foxlake|oracle-mysql|asmysql|openldap|
+        milvus|clickhouse|pika|opensearch|elasticsearch|tdengine|vllm|orioledb|official-pg|ggml|zookeeper|
+        mariadb|tidb|xinference|oracle|opengauss|influxdb|flink)'
         required: false
         default: ''
       CLOUD_PROVIDER:
@@ -28,16 +26,12 @@ on:
         options:
           - gke
           - eks
-          - aks
-          - aks-cn
       CLUSTER_VERSION:
-        description: 'k8s cluster version'
+        description: 'k8s cluster version (e.g. 1.26)'
         required: false
-        default: '1.27'
+        default: '1.26'
         type: choice
         options:
-          - 1.29
-          - 1.28
           - 1.27
           - 1.26
           - 1.25
@@ -89,11 +83,7 @@ jobs:
           if [[ "${{ inputs.CLOUD_PROVIDER }}" == 'eks' && -z "$CLUSTER_REGION" ]]; then
               CLUSTER_REGION="${{ vars.REGION_AWS_EKS }}"
           elif [[ "${{ inputs.CLOUD_PROVIDER }}" == 'gke' && -z "$CLUSTER_REGION" ]]; then
-              CLUSTER_REGION="${{ vars.REGION_GCP_GKE }}"
-          elif [[ "${{ inputs.CLOUD_PROVIDER }}" == 'aks' && -z "$CLUSTER_REGION" ]]; then
-              CLUSTER_REGION="${{ vars.REGION_AZURE_AKS }}"
-          elif [[ "${{ inputs.CLOUD_PROVIDER }}" == 'aks-cn' && -z "$CLUSTER_REGION" ]]; then
-              CLUSTER_REGION="${{ vars.REGION_AZURE_CN_AKS }}"
+              CLUSTER_REGION="${{ vars.REGION_GCP_GEK }}"
           fi
           echo cluster-region=$CLUSTER_REGION >> $GITHUB_OUTPUT
 

--- a/.github/workflows/e2e-performance.yml
+++ b/.github/workflows/e2e-performance.yml
@@ -1,4 +1,4 @@
-name: Test E2E Performance
+name: E2E Performance Test
 
 on:
   workflow_dispatch:
@@ -35,11 +35,9 @@ on:
       K8S_VERSION:
         description: 'eks version'
         required: false
-        default: '1.27'
+        default: '1.26'
         type: choice
         options:
-          - 1.29
-          - 1.28
           - 1.27
           - 1.26
           - 1.25

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -1,4 +1,4 @@
-name: Test E2E Smoke
+name: E2E Smoke Test
 
 on:
   workflow_dispatch:
@@ -24,13 +24,11 @@ on:
           - gke
           - eks
       CLUSTER_VERSION:
-        description: 'k8s cluster version'
+        description: 'k8s cluster version (e.g. 1.26)'
         required: false
-        default: '1.27'
+        default: '1.26'
         type: choice
         options:
-          - 1.29
-          - 1.28
           - 1.27
           - 1.26
           - 1.25
@@ -74,7 +72,7 @@ jobs:
           if [[ "${{ inputs.CLOUD_PROVIDER }}" == 'eks' && -z "$CLUSTER_REGION" ]]; then
               CLUSTER_REGION="${{ vars.REGION_AWS_EKS }}"
           elif [[ "${{ inputs.CLOUD_PROVIDER }}" == 'gke' && -z "$CLUSTER_REGION" ]]; then
-              CLUSTER_REGION="${{ vars.REGION_GCP_GKE }}"
+              CLUSTER_REGION="${{ vars.REGION_GCP_GEK }}"
           fi
           echo cluster-region=$CLUSTER_REGION >> $GITHUB_OUTPUT
 

--- a/.github/workflows/issues-addtoproject.yml
+++ b/.github/workflows/issues-addtoproject.yml
@@ -1,4 +1,4 @@
-name: Issues add to project
+name: ISSUES-ADD-TO-PROJECT
 
 on:
   issues:

--- a/.github/workflows/issues-labeluserdoc.yml
+++ b/.github/workflows/issues-labeluserdoc.yml
@@ -1,5 +1,4 @@
-name: Issues Handle User Doc
-
+name: ISSUES-HANDLE-USER-DOC
 on:
   issues:
     types: [labeled]

--- a/.github/workflows/issues-move.yml
+++ b/.github/workflows/issues-move.yml
@@ -1,5 +1,4 @@
-name: Issues Move
-
+name: ISSUES-MOVE
 on:
   issues:
     types: [ assigned ]
@@ -106,7 +105,6 @@ jobs:
         if: |
           github.event.action == 'published'
         run: |
-          RELEASE_BODY=$(echo "${{ github.event.release.body }}")
           cd ${{ github.workspace }}
           bash ${{ github.workspace }}/.github/utils/issue_prerelease.sh \
             ${{ env.GITHUB_TOKEN }} \
@@ -115,4 +113,4 @@ jobs:
             $PROJECT_ID \
             $STATUS_FIELD_ID \
             ${{ env.TODO_OPTION_ID }} \
-            "${RELEASE_BODY}"
+            "${{ github.event.release.body }}"

--- a/.github/workflows/issues-tagstale.yml
+++ b/.github/workflows/issues-tagstale.yml
@@ -1,5 +1,4 @@
-name: Issues Tag Stale
-
+name: ISSUES-TAG-STALE
 on:
   schedule:
   - cron: "0 0 * * 1" #Runs at 00:00 UTC on Mon

--- a/.github/workflows/merge-e2e-smoke.yml
+++ b/.github/workflows/merge-e2e-smoke.yml
@@ -1,0 +1,121 @@
+name: MERGE-E2E-SMOKE
+
+on:
+  push:
+    branches:
+      - 'main'
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  K3D_NAME: default
+  K3S_VERSION: v1.26
+  BASE_BRANCH: origin/main
+
+jobs:
+  trigger-mode:
+    runs-on: ubuntu-latest
+    outputs:
+      trigger-mode: ${{ steps.get_trigger_mode.outputs.trigger_mode }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Get trigger mode
+        id: get_trigger_mode
+        run: |
+          TRIGGER_MODE=`bash .github/utils/utils.sh --type 6 \
+              --branch-name "${{ github.ref_name }}" \
+              --base-branch "${{ env.BASE_BRANCH }}"`
+          echo $TRIGGER_MODE
+          echo trigger_mode=$TRIGGER_MODE >> $GITHUB_OUTPUT
+
+  e2e-test:
+    runs-on: [ self-hosted, k3d-runner ]
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') }}
+    needs: trigger-mode
+    strategy:
+      fail-fast: false
+      matrix:
+        test-type: [ wesql, postgresql, redis, mongodb, pulsar ]
+    name: ${{matrix.test-type}} smoke test
+    outputs:
+      runner-name1: ${{ steps.get_runner_name.outputs.runner_name1 }}
+      runner-name2: ${{ steps.get_runner_name.outputs.runner_name2 }}
+      runner-name3: ${{ steps.get_runner_name.outputs.runner_name3 }}
+      runner-name4: ${{ steps.get_runner_name.outputs.runner_name4 }}
+      runner-name5: ${{ steps.get_runner_name.outputs.runner_name5 }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: setup k3d k3s
+        uses: apecloud-inc/setup-k3d-k3s@v1
+        with:
+          k3d-name: ${{ env.K3D_NAME }}
+          version: ${{ env.K3S_VERSION }}
+          github-token: ${{ env.GITHUB_TOKEN }}
+          k3d-args: --no-lb --k3s-node-label topology.hostpath.csi/node=k3d-default-server-0@server:0
+
+      - name: install crds
+        run: |
+          make install
+
+      - name: run kubeblocks controller
+        run: |
+          export KUBECONFIG=~/.kube/config
+          go run cmd/manager/main.go &
+          sleep 30
+
+      - name: run e2e smoke test
+        run: |
+          make test-e2e-local TEST_TYPE=${{matrix.test-type}}
+
+      - name: show smoke test result
+        if: ${{ always() }}
+        run: |
+          cat ./test/e2e/*-log.txt
+          test_ret="$( grep "[ERROR]" ./test/e2e/*-log.txt || true )"
+          if [[ -n "$test_ret" ]]; then
+              exit 1
+          fi
+
+      - name: delete k3d cluster
+        if: ${{ always() }}
+        run: |
+          k3d cluster delete ${{ env.K3D_NAME }}
+
+      - name: get runner_name
+        id: get_runner_name
+        if: ${{ always() }}
+        run: |
+          TEST_TYPE="${{matrix.test-type}}"
+          case "$TEST_TYPE" in
+              wesql)
+                  echo runner_name1=${RUNNER_NAME} >> $GITHUB_OUTPUT
+              ;;
+              postgresql)
+                  echo runner_name2=${RUNNER_NAME} >> $GITHUB_OUTPUT
+              ;;
+              redis)
+                  echo runner_name3=${RUNNER_NAME} >> $GITHUB_OUTPUT
+              ;;
+              mongodb)
+                  echo runner_name4=${RUNNER_NAME} >> $GITHUB_OUTPUT
+              ;;
+              pulsar)
+                  echo runner_name5=${RUNNER_NAME} >> $GITHUB_OUTPUT
+              ;;
+          esac
+
+  remove-runner:
+    needs: [ trigger-mode, e2e-test ]
+    runs-on: ubuntu-latest
+    if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[test]') && always() }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: remove runner
+        run: |
+          RUNNER_NAME="${{ needs.e2e-test.outputs.runner-name1 }}|${{ needs.e2e-test.outputs.runner-name2 }}|${{ needs.e2e-test.outputs.runner-name3 }}|${{ needs.e2e-test.outputs.runner-name4 }}|${{ needs.e2e-test.outputs.runner-name5 }}"
+          bash .github/utils/utils.sh --type 9 \
+            --github-token "${{ env.GITHUB_TOKEN }}" \
+            --runner-name "${RUNNER_NAME}"

--- a/.github/workflows/milestone-set.yaml
+++ b/.github/workflows/milestone-set.yaml
@@ -1,4 +1,4 @@
-name: Milestone Set
+name: Set Milestone
 
 on:
   workflow_dispatch:

--- a/.github/workflows/milestoneclose.yml
+++ b/.github/workflows/milestoneclose.yml
@@ -1,4 +1,4 @@
-name: Milestones Closed
+name: Closed Milestones
 
 on:
   milestone:
@@ -7,7 +7,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.KUBEBLOCKS_TOKEN }}
   REPO: kubeblocks
-  milestone: 10
+  milestone: 8
   ORGANIZATION: apecloud
   PROJECT_NUMBER: 2
 

--- a/.github/workflows/package-version.yml
+++ b/.github/workflows/package-version.yml
@@ -1,4 +1,4 @@
-name: Package Version
+name: PACKAGE-VERSION
 
 on:
   workflow_dispatch:
@@ -38,17 +38,6 @@ jobs:
     uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.38
     with:
       GITHUB_REPO: "apecloud/kubeblocks-addons"
-      VERSION: "${{ needs.package-version.outputs.release-version }}"
-      BRANCH_NAME: "${{ needs.release-branch.outputs.release-branch }}"
-      WORKFLOW_ID: "release-version.yml"
-      APECD_REF: "v0.1.38"
-    secrets: inherit
-
-  package-addons-version-ent:
-    needs: [ package-version, release-branch ]
-    uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.38
-    with:
-      GITHUB_REPO: "apecloud/apecloud-addons"
       VERSION: "${{ needs.package-version.outputs.release-version }}"
       BRANCH_NAME: "${{ needs.release-branch.outputs.release-branch }}"
       WORKFLOW_ID: "release-version.yml"

--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -1,0 +1,83 @@
+name: Publish Images to GHCR
+
+on:
+  push:
+    branches:
+      - "**"
+    tags-ignore:
+      - "**"
+  workflow_dispatch:
+
+# Required for pushing to ghcr.io with GITHUB_TOKEN.
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-ghcr-images-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  ORG: ${{ github.repository_owner }}
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  publish:
+    name: Build and Push (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    # Only publish on the repository's default branch (i.e. after PRs merge).
+    if: github.repository_owner == env.ORG && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: kubeblocks
+            dockerfile: ./docker/Dockerfile
+            context: .
+          - image: kubeblocks-tools
+            dockerfile: ./docker/Dockerfile-tools
+            context: .
+          - image: kubeblocks-datascript
+            dockerfile: ./docker/Dockerfile-datascript
+            context: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.ORG }}/${{ matrix.image }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -1,11 +1,8 @@
-name: Pull Request Check
+name: PULL-REQUEST-CHECK
 
 on:
   pull_request_target:
     types: [ edited, opened ]
-    branches:
-      - main
-      - release-*
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -30,11 +27,9 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: check issue link
-        env:
-          PR_TITLE: ${{github.event.pull_request.title}}
         run: |
           bash ${{ github.workspace }}/.github/utils/issue_link.sh \
             ${{ github.repository }} \
             ${{ github.repository_owner }} \
             ${{ github.event.pull_request.number }} \
-            "${PR_TITLE}"
+            "${{ github.event.pull_request.title }}"

--- a/.github/workflows/pull-request-label-size.yaml
+++ b/.github/workflows/pull-request-label-size.yaml
@@ -1,11 +1,8 @@
-name: Pull Request Label Size
+name: PULL-REQUEST-LABEL-SIZE
 
 on:
   pull_request_target:
     types: [ edited, opened, synchronize ]
-    branches:
-      - main
-      - release-*
 
 
 jobs:

--- a/.github/workflows/pull-request-stats.yml
+++ b/.github/workflows/pull-request-stats.yml
@@ -1,5 +1,4 @@
-name: Pull Request Timer
-
+name: PR-TIMER
 on:
   schedule:
     - cron: '55 1 * * 3' #Runs at 06:06 UTC on Mon

--- a/.github/workflows/pull-request-user-interaction.yaml
+++ b/.github/workflows/pull-request-user-interaction.yaml
@@ -1,11 +1,8 @@
-name: Pull Request User Interact
+name: PULL-REQUEST-USER-INTERACT
 
 on:
   pull_request_target:
     types: [ edited, opened ]
-    branches:
-      - main
-      - release-*
 
 env:
   GITHUB_TOKEN: ${{ secrets.KUBEBLOCKS_TOKEN }}

--- a/.github/workflows/release-crds.yml
+++ b/.github/workflows/release-crds.yml
@@ -1,4 +1,4 @@
-name: Release KubeBlocks Install And Crds Yaml
+name: Release Crds
 
 on:
   workflow_dispatch:
@@ -17,7 +17,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
   JIHULAB_KUBEBLOCKS_PROJECT_ID: 98723
   JIHULAB_ACCESS_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
-  HELM_VERSION: v3.14.3
+  KUBEBLOCKS_CRDS: "kubeblocks_crds.yaml"
 
 jobs:
   release-version:
@@ -29,11 +29,11 @@ jobs:
       - name: Get Release Version
         id: get_release_version
         run: |
-          RELEASE_VERSION="${{ inputs.RELEASE_VERSION }}"
-          if [[ -z "$RELEASE_VERSION" ]]; then
-              RELEASE_VERSION="${{ github.ref_name }}"
+          RELASE_VERSION="${{ inputs.RELEASE_VERSION }}"
+          if [[ -z "$RELASE_VERSION" ]]; then
+              RELASE_VERSION="${{ github.ref_name }}"
           fi
-          echo release-version=$RELEASE_VERSION >> $GITHUB_OUTPUT
+          echo release-version=$RELASE_VERSION >> $GITHUB_OUTPUT
 
   create-jihulab-release:
     name: Create Release KubeBlocks Jihulab
@@ -49,76 +49,32 @@ jobs:
             --tag-name "${{ needs.release-version.outputs.release-version }}" \
             --access-token ${{ env.JIHULAB_ACCESS_TOKEN }}
 
-  upload-kubeblocks-yaml:
+  upload-kubeblocks-crds:
     needs: [ release-version, create-jihulab-release ]
-    strategy:
-      fail-fast: false
-      matrix:
-        yaml: [ 'kubeblocks_crds.yaml', 'kubeblocks.yaml' , 'dataprotection.kubeblocks.io_storageproviders.yaml', 'snapshot.storage.k8s.yaml' ]
-    name: Upload ${{ matrix.yaml }}
+    name: Upload KubeBlocks crds
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Helm
-        if: ${{ matrix.yaml == 'kubeblocks.yaml' }}
-        uses: azure/setup-helm@v4
-        with:
-          version: ${{ env.HELM_VERSION }}
-
-      - name: generate KubeBlocks yaml
-        if: ${{ matrix.yaml == 'kubeblocks.yaml' }}
-        run: |
-          BUMP_VERSION="${{ needs.release-version.outputs.release-version }}"
-          if [[ "$BUMP_VERSION" == "v"* ]]; then
-              BUMP_VERSION="${BUMP_VERSION/v/}"
-          fi
-          make bump-chart-ver VERSION="${BUMP_VERSION}"
-          touch ${{ matrix.yaml }}
-          helm template kubeblocks deploy/helm --dependency-update > ${{ matrix.yaml }}
-
       - name: merge KubeBlocks crds
-        if: ${{ matrix.yaml == 'kubeblocks_crds.yaml' }}
         run: |
-          touch ${{ matrix.yaml }}
           crds_path="deploy/helm/crds"
+          KUBEBLOCKS_CRDS=${{ env.KUBEBLOCKS_CRDS }}
+          touch $KUBEBLOCKS_CRDS
           crds_list=$(ls $crds_path)
           for crd in $(echo $crds_list); do
-              if [[ ! -f $crds_path/$crd ]]; then
-                  continue
-              fi
-              echo "---" >> ${{ matrix.yaml }}
-              cat $crds_path/$crd >> ${{ matrix.yaml }}
+              echo "---" >> $KUBEBLOCKS_CRDS
+              cat $crds_path/$crd >> $KUBEBLOCKS_CRDS
           done
 
-      - name: release dataprotection.kubeblocks.io_storageproviders
-        if: ${{ matrix.yaml == 'dataprotection.kubeblocks.io_storageproviders.yaml' }}
+      - name: upload KubeBlocks crds to jihulab
         run: |
-          cp -r deploy/helm/crds/${{ matrix.yaml }} ${{ matrix.yaml }}
-
-      - name: merge snapshot crds
-        if: ${{ matrix.yaml == 'snapshot.storage.k8s.yaml' }}
-        run: |
-          touch ${{ matrix.yaml }}
-          crds_path="deploy/helm/crds/snapshot"
-          crds_list=$(ls $crds_path)
-          for crd in $(echo $crds_list); do
-              if [[ ! -f $crds_path/$crd ]]; then
-                  continue
-              fi
-              echo "---" >> ${{ matrix.yaml }}
-              cat $crds_path/$crd >> ${{ matrix.yaml }}
-          done
-
-      - name: upload KubeBlocks yaml to jihulab
-        run: |
-          echo "Processing file: ${{ matrix.yaml }}"
+          echo "Processing file: ${{ env.KUBEBLOCKS_CRDS }}"
           bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
               --type 2 \
               --project-id ${{ env.JIHULAB_KUBEBLOCKS_PROJECT_ID }} \
               --tag-name "${{ needs.release-version.outputs.release-version }}" \
-              --asset-path ${{ github.workspace }}/${{ matrix.yaml }} \
-              --asset-name ${{ matrix.yaml }} \
+              --asset-path ${{ github.workspace }}/${{ env.KUBEBLOCKS_CRDS }} \
+              --asset-name ${{ env.KUBEBLOCKS_CRDS }} \
               --access-token ${{ env.JIHULAB_ACCESS_TOKEN }}
 
       - name: get KubeBlocks release upload url
@@ -129,10 +85,10 @@ jobs:
             --github-repo ${{ github.repository }} \
             --github-token ${{ env.GITHUB_TOKEN }}` >> $GITHUB_ENV
 
-      - name: upload KubeBlocks yaml to github
+      - name: upload KubeBlocks crds to github
         uses: actions/upload-release-asset@main
         with:
           upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ${{ github.workspace }}/${{ matrix.yaml }}
-          asset_name: ${{ matrix.yaml }}
+          asset_path: ${{ github.workspace }}/${{ env.KUBEBLOCKS_CRDS }}
+          asset_name: ${{ env.KUBEBLOCKS_CRDS }}
           asset_content_type: application/yaml

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -1,4 +1,4 @@
-name: Release Create
+name: RELEASE-CREATE
 
 on:
   push:
@@ -25,7 +25,7 @@ jobs:
           echo rel_version=v${{ env.REL_VERSION }} >> $GITHUB_OUTPUT
 
       - name: release pre-release without release notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         if: not ${{ env.WITH_RELEASE_NOTES }}
         with:
           # body_path: ./docs/release_notes/v${{ env.REL_VERSION }}/v${{ env.REL_VERSION }}.md
@@ -35,7 +35,7 @@ jobs:
           tag_name: v${{ env.REL_VERSION }}
           prerelease: true
       - name: release RC with release notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         if: ${{ env.WITH_RELEASE_NOTES }}
         with:
           body_path: ./docs/release_notes/v${{ env.REL_VERSION }}/v${{ env.REL_VERSION }}.md

--- a/.github/workflows/release-delete.yml
+++ b/.github/workflows/release-delete.yml
@@ -1,4 +1,4 @@
-name: Release Delete
+name: RELEASE-DELETE
 
 on:
   schedule:

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -1,4 +1,4 @@
-name: Release Charts
+name: Release Chart
 
 on:
   workflow_dispatch:
@@ -14,7 +14,6 @@ on:
 env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}
-  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   release-version:
@@ -34,49 +33,60 @@ jobs:
           RELEASE_VERSION_BUMP="${RELEASE_VERSION/v/}"
           echo release_version_bump=$RELEASE_VERSION_BUMP >> $GITHUB_OUTPUT
 
+  precheck-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Docker Hub secrets
+        run: |
+          missing=()
+          if [[ -z "${{ secrets.DOCKER_REGISTRY_USER }}" ]]; then
+            missing+=("DOCKER_REGISTRY_USER")
+          fi
+          if [[ -z "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" ]]; then
+            missing+=("DOCKER_REGISTRY_PASSWORD")
+          fi
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error title=Missing secrets::${missing[*]} are not set in repository secrets"
+            exit 1
+          fi
+
   release-chart:
     needs: [ release-version ]
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.86
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.43
     with:
       MAKE_OPS: "bump-chart-ver"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
       CHART_NAME: "kubeblocks"
       CHART_DIR: "deploy/helm"
-      APECD_REF: "v0.1.86"
+      APECD_REF: "v0.1.43"
       MAKE_OPS_POST: "install"
       GO_VERSION: "1.21"
     secrets: inherit
 
   release-addons-chart:
     needs: [ release-chart ]
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.86
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts.yml@v0.1.52
     with:
       GITHUB_REPO: "apecloud/kubeblocks-addons"
-      GITHUB_REF: "${{ github.ref_name }}"
+      GITHUB_REF: ${{ github.ref }}
       CHART_DIR: "addons"
-      APECD_REF: "v0.1.86"
+      APECD_REF: "v0.1.52"
       ENABLE_JIHU: false
     secrets: inherit
 
-  release-addons-cluster-chart:
-    needs: [ release-addons-chart ]
-    uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.86
-    with:
-      GITHUB_REPO: "apecloud/kubeblocks-addons"
-      BRANCH_NAME: "${{ github.ref_name }}"
-      WORKFLOW_ID: "release-addons-cluster-chart.yml"
-      APECD_REF: "v0.1.86"
-    secrets: inherit
-
   release-charts-image:
-    needs: [ release-version, release-addons-chart ]
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.86
+    permissions:
+      contents: read
+      id-token: write
+    needs: [ release-version, release-addons-chart, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
       MAKE_OPS_PRE: "helm-package VERSION=${{ needs.release-version.outputs.release-version-bump }}"
-      IMG: "apecloud/kubeblocks-charts"
+      IMG: "wallykk/kubeblocks-charts"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       GO_VERSION: "1.21"
-      APECD_REF: "v0.1.86"
+      APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-charts"
     secrets: inherit
 
@@ -120,13 +130,16 @@ jobs:
           key: ${{ steps.release_message.outputs.artifact_key }}
 
   send-message:
+    permissions:
+      contents: read
+      id-token: write
     needs: [ release-message ]
     if: ${{ always() && github.event.action == 'published' }}
-    uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.86
+    uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.38
     with:
       TYPE: "2"
       CONTENT: "release chart ${{ needs.release-message.outputs.release-version }} ${{ needs.release-message.outputs.content-result }}"
-      APECD_REF: "v0.1.86"
+      APECD_REF: "v0.1.38"
     secrets: inherit
 
   get-addons-chart-dir:
@@ -139,7 +152,7 @@ jobs:
         with:
           repository: apecloud/kubeblocks-addons
           path: kubeblocks-addons
-          ref: "${{ github.ref_name }}"
+          ref: ${{ github.ref }}
       - name: get addons chart dir
         id: get_addons_chart_dir
         run: |
@@ -160,64 +173,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.get-addons-chart-dir.outputs.matrix) }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.86
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu.yml@v0.1.52
     with:
       GITHUB_REPO: "apecloud/kubeblocks-addons"
-      GITHUB_REF: "${{ github.ref_name }}"
+      GITHUB_REF: ${{ github.ref }}
       CHART_DIR: "addons"
       SPECIFY_CHART: "${{ matrix.addon-name }}"
-      APECD_REF: "v0.1.86"
-    secrets: inherit
-
-  release-addons-chart-ent:
-    needs: [ release-chart ]
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-enterprise.yml@v0.1.86
-    with:
-      GITHUB_REPO: "apecloud/apecloud-addons"
-      GITHUB_REF: "${{ github.ref_name }}"
-      CHART_DIR: "addons"
-      APECD_REF: "v0.1.86"
-      ENABLE_JIHU: false
-    secrets: inherit
-
-  get-addons-chart-dir-ent:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.get_addons_chart_dir.outputs.matrix }}
-    steps:
-      - name: Checkout apecloud-addons Code
-        uses: actions/checkout@v4
-        with:
-          repository: apecloud/apecloud-addons
-          path: apecloud-addons
-          ref: "${{ github.ref_name }}"
-          token: ${{ env.GITHUB_TOKEN }}
-
-      - name: get addons chart dir
-        id: get_addons_chart_dir
-        run: |
-          addons_list=$(ls apecloud-addons/addons)
-          ADDONS_DIR=""
-          for addons_name in $( echo "$addons_list" ); do
-              if [[ -z "$ADDONS_DIR" ]]; then
-                  ADDONS_DIR="{\"addon-name\":\"$addons_name\"}"
-              else
-                  ADDONS_DIR="$ADDONS_DIR,{\"addon-name\":\"$addons_name\"}"
-              fi
-          done
-          echo "$ADDONS_DIR"
-          echo "matrix={\"include\":[$ADDONS_DIR]}" >> $GITHUB_OUTPUT
-
-  release-addons-chart-jihu-ent:
-    needs: [ get-addons-chart-dir-ent ]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.get-addons-chart-dir-ent.outputs.matrix) }}
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu-enterprise.yml@v0.1.86
-    with:
-      GITHUB_REPO: "apecloud/apecloud-addons"
-      GITHUB_REF: "${{ github.ref_name }}"
-      CHART_DIR: "addons"
-      SPECIFY_CHART: "${{ matrix.addon-name }}"
-      APECD_REF: "v0.1.86"
+      APECD_REF: "v0.1.52"
     secrets: inherit

--- a/.github/workflows/release-image-cache.yml
+++ b/.github/workflows/release-image-cache.yml
@@ -1,0 +1,308 @@
+name: Release Image Cache
+
+on:
+  workflow_call:
+    inputs:
+      GITHUB_REPO:
+        description: "The github repo to release image"
+        type: string
+        required: false
+        default: ''
+      GITHUB_REF:
+        description: "The github repo ref to release image"
+        type: string
+        required: false
+        default: 'main'
+      MAKE_OPS_PRE:
+        description: "The pre ops name of makefile (e.g. generate)"
+        type: string
+        required: false
+        default: ''
+      IMG:
+        description: "The URL to use building/pushing image targets (e.g. apecloud/kubeblocks)"
+        type: string
+        required: false
+        default: ''
+      VERSION:
+        description: "The tag name of image (default: latest)"
+        type: string
+        required: false
+        default: ''
+      BUILDX_PLATFORMS:
+        description: "buildx platforms (default: linux/amd64,linux/arm64)"
+        type: string
+        required: false
+        default: 'linux/amd64,linux/arm64'
+      BUILDX_ARGS:
+        description: "buildx args "
+        type: string
+        required: false
+        default: ''
+      GO_VERSION:
+        description: "Install the specify version of GO"
+        type: string
+        required: false
+        default: ''
+      GIT_CONFIG:
+        description: "InsteadOf git config global url (default: false)"
+        type: boolean
+        required: false
+        default: false
+      APECD_REF:
+        description: "The branch name of apecloud-cd"
+        type: string
+        required: false
+        default: 'main'
+      SYNC_ENABLE:
+        description: "Enable sync images"
+        type: boolean
+        required: false
+        default: true
+      CONTEXT:
+        description: "Build's context is the set of files located in the specified PATH or URL (default: .)"
+        type: string
+        required: false
+        default: '.'
+      DOCKERFILE_PATH:
+        description: "Path to the Dockerfile (default: ./Dockerfile)"
+        type: string
+        required: false
+        default: './Dockerfile'
+      REMOVE_PREFIX:
+        description: "Enable remove prefix v  (default: true)"
+        type: boolean
+        required: false
+        default: true
+      PYTHON_VERSION:
+        description: "Install the specify version of Python"
+        type: string
+        required: false
+        default: ''
+      POETRY_VERSION:
+        description: "Install the specify version of Poetry"
+        type: string
+        required: false
+        default: ''
+      ENABLE_SUBMODULE:
+        description: "Enable checkout submodule  (default: false)"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  DOCKER_REGISTRY_URL: docker.io
+  ALIYUN_REGISTRY_URL: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
+  ALIYUN_REGISTRY_URL_NEW: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+  GOOGLE_REGISTRY_URL: us-east1-docker.pkg.dev
+  DOCKER_USER: ${{ secrets.DOCKER_REGISTRY_USER }}
+  DOCKER_PASSWORD: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
+  ALIYUN_USER: ${{ secrets.ALIYUN_REGISTRY_USER }}
+  ALIYUN_PASSWORD: ${{ secrets.ALIYUN_REGISTRY_PASSWORD }}
+  ALIYUN_USER_NEW: ${{ secrets.ALIYUN_USER_NEW }}
+  ALIYUN_PASSWORD_NEW: ${{ secrets.ALIYUN_PASSWORD_NEW }}
+  GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
+  GOOGLE_SERVICE_ACCOUNT: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
+  GITHUB_USER: ${{ secrets.PERSONAL_ACCESS_USER }}
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  CONTROLLER_MANAGER_CFG: ${{ secrets.CONTROLLER_MANAGER_CFG }}
+  OPENCONSOLE_CFG: ${{ secrets.OPENCONSOLE_CFG }}
+  CONSOLE_PROXY_CFG: ${{ secrets.CONSOLE_PROXY_CFG }}
+
+jobs:
+  release-image:
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    runs-on: ubuntu-latest
+    outputs:
+      tag-name: ${{ steps.get_tag_name.outputs.tag-name }}
+    steps:
+      - name: Checkout Code
+        if: ${{ ! inputs.ENABLE_SUBMODULE && inputs.GITHUB_REPO == '' }}
+        uses: actions/checkout@v4
+
+      - name: Checkout ${{ inputs.GITHUB_REPO }} Code
+        if: ${{ ! inputs.ENABLE_SUBMODULE && inputs.GITHUB_REPO != '' }}
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.GITHUB_REPO }}
+          path: ./
+          token: ${{ env.GITHUB_TOKEN }}
+          ref: ${{ inputs.GITHUB_REF }}
+
+      - name: Checkout Code With Submodule
+        if: ${{ inputs.ENABLE_SUBMODULE && inputs.GITHUB_REPO == '' }}
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          token: ${{ env.GITHUB_TOKEN }}
+
+      - name: Checkout ${{ inputs.GITHUB_REPO }} Code With Submodule
+        if: ${{ inputs.ENABLE_SUBMODULE && inputs.GITHUB_REPO != '' }}
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          repository: ${{ inputs.GITHUB_REPO }}
+          path: ./
+          token: ${{ env.GITHUB_TOKEN }}
+          ref: ${{ inputs.GITHUB_REF }}
+
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:master
+
+      - name: Setup Go specify version
+        if: inputs.GO_VERSION
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ inputs.GO_VERSION }}
+
+      - name: Setup Python specify version
+        if: inputs.PYTHON_VERSION
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ inputs.PYTHON_VERSION }}"
+
+      - name: Setup Poetry specify version
+        if: inputs.POETRY_VERSION
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "${{ inputs.POETRY_VERSION }}"
+
+      - name: Setup Python specify version
+        if: inputs.PYTHON_VERSION
+        uses: actions/setup-python@v4
+        with:
+          python-version: "${{ inputs.PYTHON_VERSION }}"
+
+      - name: Setup Poetry specify version
+        if: inputs.POETRY_VERSION
+        uses: Gr1N/setup-poetry@v8
+        with:
+          poetry-version: "${{ inputs.POETRY_VERSION }}"
+
+      - name: git config
+        if: inputs.GIT_CONFIG
+        run: |
+          git config --global url."https://${{ env.GITHUB_USER }}:${{ env.GITHUB_TOKEN }}@github.com".insteadof "https://github.com"
+
+      - name: make pre
+        if: inputs.MAKE_OPS_PRE
+        run: |
+          if [[ -n "${{ inputs.MAKE_OPS_PRE }}" && ! ("${{ inputs.MAKE_OPS_PRE }}" == "helm-package VERSION=latest" && "${{ inputs.IMG }}" == "apecloud/kubeblocks-charts" ) ]]; then
+              make ${{ inputs.MAKE_OPS_PRE }}
+          fi
+
+      - name: remove v prefix
+        id: get_tag_name
+        shell: bash
+        run: |
+          tag_name="${{ inputs.VERSION }}"
+          if [[ "$tag_name" == "v"*  && "${{ inputs.REMOVE_PREFIX }}" == "true" ]]; then
+              tag_name="${tag_name/v/}"
+          fi
+          echo tag-name=$tag_name >> $GITHUB_OUTPUT
+
+      - if: ${{ env.DOCKER_USER != '' && env.DOCKER_PASSWORD != '' }}
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.DOCKER_REGISTRY_URL }}
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - if: ${{ env.DOCKER_USER != '' && env.DOCKER_PASSWORD != '' }}
+        name: Build and Push to Docker Hub
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.CONTEXT }}
+          file: ${{ inputs.DOCKERFILE_PATH }}
+          tags: ${{ env.DOCKER_REGISTRY_URL }}/${{ inputs.IMG }}:${{ steps.get_tag_name.outputs.tag-name }}
+          platforms: ${{ inputs.BUILDX_PLATFORMS }}
+          build-args: ${{ inputs.BUILDX_ARGS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - if: ${{ env.ALIYUN_USER != '' && env.ALIYUN_PASSWORD != '' }}
+        name: Login to Aliyun Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY_URL }}
+          username: ${{ env.ALIYUN_USER }}
+          password: ${{ env.ALIYUN_PASSWORD }}
+
+      - if: ${{ env.ALIYUN_USER != '' && env.ALIYUN_PASSWORD != '' }}
+        name: Build and Push to Aliyun Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.CONTEXT }}
+          file: ${{ inputs.DOCKERFILE_PATH }}
+          tags: ${{ env.ALIYUN_REGISTRY_URL }}/${{ inputs.IMG }}:${{ steps.get_tag_name.outputs.tag-name }}
+          platforms: ${{ inputs.BUILDX_PLATFORMS }}
+          build-args: ${{ inputs.BUILDX_ARGS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - if: ${{ env.ALIYUN_USER_NEW != '' && env.ALIYUN_PASSWORD_NEW != '' }}
+        name: Login to Aliyun Registry New
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.ALIYUN_REGISTRY_URL_NEW }}
+          username: ${{ env.ALIYUN_USER_NEW }}
+          password: ${{ env.ALIYUN_PASSWORD_NEW }}
+
+      - if: ${{ env.ALIYUN_USER_NEW != '' && env.ALIYUN_PASSWORD_NEW != '' }}
+        name: Build and Push to Aliyun Registry New
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.CONTEXT }}
+          file: ${{ inputs.DOCKERFILE_PATH }}
+          tags: ${{ env.ALIYUN_REGISTRY_URL_NEW }}/${{ inputs.IMG }}:${{ steps.get_tag_name.outputs.tag-name }}
+          platforms: ${{ inputs.BUILDX_PLATFORMS }}
+          build-args: ${{ inputs.BUILDX_ARGS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - if: ${{ env.GOOGLE_CREDENTIALS != '' }}
+        id: 'auth'
+        name: 'Authenticate to Google Cloud'
+        uses: 'google-github-actions/auth@v2.1.8'
+        with:
+          credentials_json: '${{ env.GOOGLE_CREDENTIALS }}'
+
+      - if: ${{ env.GOOGLE_CREDENTIALS != '' && env.GOOGLE_SERVICE_ACCOUNT != ''  }}
+        name: Build and Push to Google Registry
+        run: |
+          GOOGLE_REGISTRY_URL=${{ env.GOOGLE_REGISTRY_URL }}
+          
+          gcloud auth activate-service-account \
+             ${{ env.GOOGLE_SERVICE_ACCOUNT }} \
+             --key-file=${{ steps.auth.outputs.credentials_file_path }}
+          
+          gcloud auth configure-docker $GOOGLE_REGISTRY_URL
+
+      - if: ${{ env.GOOGLE_CREDENTIALS != '' && env.GOOGLE_SERVICE_ACCOUNT != ''  }}
+        name: Build and Push to Google Registry
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ inputs.CONTEXT }}
+          file: ${{ inputs.DOCKERFILE_PATH }}
+          tags: ${{ env.GOOGLE_REGISTRY_URL }}/${{ inputs.IMG }}:${{ steps.get_tag_name.outputs.tag-name }}
+          platforms: ${{ inputs.BUILDX_PLATFORMS }}
+          build-args: ${{ inputs.BUILDX_ARGS }}
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -9,6 +9,34 @@ on:
         description: 'The release version of image'
         required: false
         default: 'latest'
+      image_repo:
+        description: 'Image repository for kubeblocks (e.g. wallykk/kubeblocks)'
+        required: false
+        default: 'wallykk/kubeblocks'
+      tools_image_repo:
+        description: 'Image repository for kubeblocks-tools (e.g. wallykk/kubeblocks-tools)'
+        required: false
+        default: 'wallykk/kubeblocks-tools'
+      datascript_image_repo:
+        description: 'Image repository for kubeblocks-datascript (e.g. wallykk/kubeblocks-datascript)'
+        required: false
+        default: 'wallykk/kubeblocks-datascript'
+      dataprotection_image_repo:
+        description: 'Image repository for kubeblocks-dataprotection (e.g. wallykk/kubeblocks-dataprotection)'
+        required: false
+        default: 'wallykk/kubeblocks-dataprotection'
+      charts_image_repo:
+        description: 'Image repository for kubeblocks-charts (e.g. wallykk/kubeblocks-charts)'
+        required: false
+        default: 'wallykk/kubeblocks-charts'
+      dev_image_repo:
+        description: 'Image repository for kubeblocks-dev (e.g. wallykk/kubeblocks-dev)'
+        required: false
+        default: 'wallykk/kubeblocks-dev'
+      image_targets:
+        description: 'Comma-separated targets: kubeblocks,tools,datascript,dataprotection,charts,dev or all'
+        required: false
+        default: 'all'
       dockerfile:
         description: 'release specify Dockerfile or empty to release all images'
         required: false
@@ -36,10 +64,7 @@ jobs:
     outputs:
       release-version: ${{ steps.get_release_version.outputs.release_version }}
       release-version-bump: ${{ steps.get_release_version.outputs.release_version_bump }}
-      git-commit: ${{ steps.get_git_info.outputs.git_commit }}
-      git-version: ${{ steps.get_git_info.outputs.git_version }}
     steps:
-      - uses: actions/checkout@v4
       - name: Get Release Version
         id: get_release_version
         run: |
@@ -55,86 +80,115 @@ jobs:
           RELEASE_VERSION_BUMP="${RELEASE_VERSION/v/}"
           echo release_version_bump=$RELEASE_VERSION_BUMP >> $GITHUB_OUTPUT
 
-      - name: get git info
-        id: get_git_info
+  precheck-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Docker Hub secrets
         run: |
-          GIT_COMMIT=$(git rev-list -1 HEAD)
-          GIT_VERSION=$(git describe --always --abbrev=0 --tag)
-          echo git_commit=$GIT_COMMIT >> $GITHUB_OUTPUT
-          echo git_version=$GIT_VERSION >> $GITHUB_OUTPUT
+          missing=()
+          if [[ -z "${{ secrets.DOCKER_REGISTRY_USER }}" ]]; then
+            missing+=("DOCKER_REGISTRY_USER")
+          fi
+          if [[ -z "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" ]]; then
+            missing+=("DOCKER_REGISTRY_PASSWORD")
+          fi
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error title=Missing secrets::${missing[*]} are not set in repository secrets"
+            exit 1
+          fi
 
   release-image:
-    if: ${{ inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile' }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.64
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',kubeblocks,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
       MAKE_OPS_PRE: "generate"
-      IMG: "apecloud/kubeblocks"
+      IMG: "${{ inputs.image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       GO_VERSION: "1.21"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile"
-      BUILDX_ARGS: |
-        VERSION=${{ needs.release-version.outputs.release-version }}
-        GIT_COMMIT=${{ needs.release-version.outputs.git-commit }}
-        GIT_VERSION=${{ needs.release-version.outputs.git-version }}
     secrets: inherit
 
   release-tools-image:
-    if: ${{ inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-tools' }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',tools,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-tools') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
       MAKE_OPS_PRE: "module generate test-go-generate"
-      IMG: "apecloud/kubeblocks-tools"
+      IMG: "${{ inputs.tools_image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       GO_VERSION: "1.21"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-tools"
     secrets: inherit
 
   release-datascript-image:
-    if: ${{ inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-datascript' }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',datascript,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-datascript') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
-      IMG: "apecloud/kubeblocks-datascript"
+      IMG: "${{ inputs.datascript_image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-datascript"
     secrets: inherit
 
   release-dataprotection-image:
-    if: ${{ inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dataprotection' }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dataprotection,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dataprotection') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
-      IMG: "apecloud/kubeblocks-dataprotection"
+      IMG: "${{ inputs.dataprotection_image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-dataprotection"
     secrets: inherit
 
   release-charts-image:
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-charts') }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',charts,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-charts') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
       MAKE_OPS_PRE: "helm-package VERSION=${{ needs.release-version.outputs.release-version-bump }}"
-      IMG: "apecloud/kubeblocks-charts"
+      IMG: "${{ inputs.charts_image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       GO_VERSION: "1.21"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-charts"
     secrets: inherit
 
   release-dev-image:
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dev') }}
-    needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    permissions:
+      contents: read
+      id-token: write
+    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dev,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dev') }}
+    needs: [ release-version, precheck-secrets ]
+    uses: ./.github/workflows/release-image-cache.yml
     with:
-      IMG: "apecloud/kubeblocks-dev"
+      IMG: "${{ inputs.dev_image_repo }}"
       VERSION: "${{ needs.release-version.outputs.release-version }}"
+      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
       APECD_REF: "v0.1.24"
       DOCKERFILE_PATH: "./docker/Dockerfile-dev"
       CONTEXT: "./docker"
@@ -180,6 +234,9 @@ jobs:
           key: ${{ steps.release_message.outputs.artifact_key }}
 
   send-message:
+    permissions:
+      contents: read
+      id-token: write
     needs: [ release-message ]
     if: ${{ always() && github.event.action == 'published' }}
     uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.38
@@ -218,11 +275,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ apecloud-mysql|postgresql|redis|mongodb|kafka|asmysql|elasticsearch|zookeeper|rabbitmq|damengdb|kingbase|gaussdb,
-                     pulsar|mysqlscale|weaviate|qdrant|smartengine|greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|mssql,
-                     foxlake|orioledb|oracle-mysql|vanilla-pg|openldap|polardbx|opensearch|vllm|tdengine|milvus|clickhouse|vastbase,
-                     pika|ggml|mariadb|tidb|xinference|oracle|opengauss|influxdb|flink|solr|doris|loki|victoria-metrics,
-                     halo|mogdb|oceanbase-ent|starrocks-ent|apecloud-postgresql|yashandb|redis-cluster|camellia-redis-proxy|dmdb|minio|orchestrator|rocketmq ]
+        test-type: [ apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|mysqlscale|weaviate|qdrant|smartengine,
+                     greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|foxlake|orioledb|oracle-mysql|official-pg|asmysql|openldap,
+                     polardbx|opensearch|elasticsearch|vllm|tdengine|milvus|clickhouse|pika|ggml|zookeeper|mariadb,
+                     tidb|xinference|oracle|opengauss|influxdb|flink|mogdb|redis-cluster|camellia-redis-proxy|pulsar-nodeport ]
     with:
       GITHUB_REPO: "apecloud/kubeblocks"
       BRANCH_NAME: "main"
@@ -244,4 +300,3 @@ jobs:
         continue-on-error: true
         run: |
           bash .github/utils/utils.sh --type 17 --tag-name "${{ env.RELEASE_VERSION }}-${{ matrix.type }}"
-

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -10,53 +10,29 @@ on:
         required: false
         default: 'latest'
       image_repo:
-        description: 'Image repository for kubeblocks (e.g. wallykk/kubeblocks)'
-        required: false
-        default: 'wallykk/kubeblocks'
-      tools_image_repo:
-        description: 'Image repository for kubeblocks-tools (e.g. wallykk/kubeblocks-tools)'
-        required: false
-        default: 'wallykk/kubeblocks-tools'
-      datascript_image_repo:
-        description: 'Image repository for kubeblocks-datascript (e.g. wallykk/kubeblocks-datascript)'
-        required: false
-        default: 'wallykk/kubeblocks-datascript'
-      dataprotection_image_repo:
-        description: 'Image repository for kubeblocks-dataprotection (e.g. wallykk/kubeblocks-dataprotection)'
-        required: false
-        default: 'wallykk/kubeblocks-dataprotection'
-      charts_image_repo:
-        description: 'Image repository for kubeblocks-charts (e.g. wallykk/kubeblocks-charts)'
-        required: false
-        default: 'wallykk/kubeblocks-charts'
-      dev_image_repo:
-        description: 'Image repository for kubeblocks-dev (e.g. wallykk/kubeblocks-dev)'
-        required: false
-        default: 'wallykk/kubeblocks-dev'
-      image_targets:
-        description: 'Comma-separated targets: kubeblocks,tools,datascript,dataprotection,charts,dev or all'
-        required: false
-        default: 'all'
-      dockerfile:
-        description: 'release specify Dockerfile or empty to release all images'
+        description: 'Image repository for kubeblocks (e.g. ghcr.io/labring/kubeblocks)'
         required: false
         default: ''
-        type: choice
-        options:
-          - ""
-          - Dockerfile
-          - Dockerfile-charts
-          - Dockerfile-dataprotection
-          - Dockerfile-datascript
-          - Dockerfile-dev
-          - Dockerfile-tools
+      tools_image_repo:
+        description: 'Image repository for kubeblocks-tools (e.g. ghcr.io/labring/kubeblocks-tools)'
+        required: false
+        default: ''
+      datascript_image_repo:
+        description: 'Image repository for kubeblocks-datascript (e.g. ghcr.io/labring/kubeblocks-datascript)'
+        required: false
+        default: ''
   release:
     types:
       - published
 
+permissions:
+  contents: write
+
 env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}
+  REGISTRY: ghcr.io
+  ORG: ${{ github.repository_owner }}
 
 jobs:
   release-version:
@@ -80,223 +56,58 @@ jobs:
           RELEASE_VERSION_BUMP="${RELEASE_VERSION/v/}"
           echo release_version_bump=$RELEASE_VERSION_BUMP >> $GITHUB_OUTPUT
 
-  precheck-secrets:
+  publish-ghcr-images:
+    permissions:
+      contents: read
+      packages: write
+    needs: [ release-version ]
     runs-on: ubuntu-latest
-    steps:
-      - name: Check Docker Hub secrets
-        run: |
-          missing=()
-          if [[ -z "${{ secrets.DOCKER_REGISTRY_USER }}" ]]; then
-            missing+=("DOCKER_REGISTRY_USER")
-          fi
-          if [[ -z "${{ secrets.DOCKER_REGISTRY_PASSWORD }}" ]]; then
-            missing+=("DOCKER_REGISTRY_PASSWORD")
-          fi
-          if (( ${#missing[@]} > 0 )); then
-            echo "::error title=Missing secrets::${missing[*]} are not set in repository secrets"
-            exit 1
-          fi
-
-  release-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',kubeblocks,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "generate"
-      IMG: "${{ inputs.image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile"
-    secrets: inherit
-
-  release-tools-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',tools,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-tools') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "module generate test-go-generate"
-      IMG: "${{ inputs.tools_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-tools"
-    secrets: inherit
-
-  release-datascript-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',datascript,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-datascript') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.datascript_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-datascript"
-    secrets: inherit
-
-  release-dataprotection-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dataprotection,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dataprotection') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.dataprotection_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-dataprotection"
-    secrets: inherit
-
-  release-charts-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',charts,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-charts') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      MAKE_OPS_PRE: "helm-package VERSION=${{ needs.release-version.outputs.release-version-bump }}"
-      IMG: "${{ inputs.charts_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      GO_VERSION: "1.21"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-charts"
-    secrets: inherit
-
-  release-dev-image:
-    permissions:
-      contents: read
-      id-token: write
-    if: ${{ github.event_name  == 'workflow_dispatch' && (inputs.image_targets == '' || inputs.image_targets == 'all' || contains(format(',{0},', inputs.image_targets), ',dev,')) && (inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-dev') }}
-    needs: [ release-version, precheck-secrets ]
-    uses: ./.github/workflows/release-image-cache.yml
-    with:
-      IMG: "${{ inputs.dev_image_repo }}"
-      VERSION: "${{ needs.release-version.outputs.release-version }}"
-      BUILDX_PLATFORMS: "linux/amd64,linux/arm64"
-      APECD_REF: "v0.1.24"
-      DOCKERFILE_PATH: "./docker/Dockerfile-dev"
-      CONTEXT: "./docker"
-    secrets: inherit
-
-  release-message:
-    runs-on: ubuntu-latest
-    needs: [ release-image, release-tools-image, release-datascript-image, release-dataprotection-image ]
-    outputs:
-      content-result: ${{ steps.release_message.outputs.content_result }}
-      release-version: ${{ steps.release_message.outputs.release_version }}
-    if: ${{ always() && github.event.action == 'published' }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: release message
-        id: release_message
-        run: |
-          ARTIFACT_KEY="${{ env.RELEASE_VERSION }}-image"
-          touch ${ARTIFACT_KEY}
-          echo 'artifact_key='${ARTIFACT_KEY} >> $GITHUB_OUTPUT
-
-          CONTENT="error"
-          if [[ "${{ needs.release-image.result }}" == "success" && "${{ needs.release-tools-image.result }}" == "success"  && "${{ needs.release-datascript-image.result }}" == "success" && "${{ needs.release-dataprotection-image.result }}" == "success" ]]; then
-              CONTENT="success"
-              echo "success" > ${ARTIFACT_KEY}
-          else
-              echo "error" > ${ARTIFACT_KEY}
-          fi
-          echo 'content_result='$CONTENT >> $GITHUB_OUTPUT
-          echo release_version=${{ env.RELEASE_VERSION }} >> $GITHUB_OUTPUT
-
-      - name: delete cache
-        continue-on-error: true
-        run: |
-          bash .github/utils/utils.sh --type 17 --tag-name "${{ steps.release_message.outputs.artifact_key }}"
-
-      - name: Save Artifact
-        id: cache-artifact-save
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            ${{ steps.release_message.outputs.artifact_key }}
-          key: ${{ steps.release_message.outputs.artifact_key }}
-
-  send-message:
-    permissions:
-      contents: read
-      id-token: write
-    needs: [ release-message ]
-    if: ${{ always() && github.event.action == 'published' }}
-    uses: apecloud/apecloud-cd/.github/workflows/feishui-message.yml@v0.1.38
-    with:
-      TYPE: "2"
-      CONTENT: "release image ${{ needs.release-message.outputs.release-version }} ${{ needs.release-message.outputs.content-result }}"
-      APECD_REF: "v0.1.38"
-    secrets: inherit
-
-  release-result:
-    if: github.event.action == 'published'
-    needs: [ release-message ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        type: [image, chart]
-    steps:
-      - name: Restore ${{ matrix.type }} Artifact
-        id: cache-artifact-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            ${{ env.RELEASE_VERSION }}-${{ matrix.type }}
-          key: ${{ env.RELEASE_VERSION }}-${{ matrix.type }}
-
-      - name: check release result
-        run: |
-          release_result=$( cat ${{ env.RELEASE_VERSION }}-${{ matrix.type }} )
-          if [[ "$release_result" != "success" ]]; then
-              exit 1
-          fi
-
-  e2e-kbcli:
-    needs: [ release-message, release-result ]
-    uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.35
     strategy:
       fail-fast: false
       matrix:
-        test-type: [ apecloud-mysql|postgresql|redis|mongodb|kafka|pulsar|mysqlscale|weaviate|qdrant|smartengine,
-                     greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|foxlake|orioledb|oracle-mysql|official-pg|asmysql|openldap,
-                     polardbx|opensearch|elasticsearch|vllm|tdengine|milvus|clickhouse|pika|ggml|zookeeper|mariadb,
-                     tidb|xinference|oracle|opengauss|influxdb|flink|mogdb|redis-cluster|camellia-redis-proxy|pulsar-nodeport ]
-    with:
-      GITHUB_REPO: "apecloud/kubeblocks"
-      BRANCH_NAME: "main"
-      WORKFLOW_ID: "e2e-kbcli.yml"
-      APECD_REF: "v0.1.35"
-      VERSION: "${{ needs.release-message.outputs.release-version }}"
-      EXTRA_ARGS: "TEST_TYPE=${{ matrix.test-type }}#CLOUD_PROVIDER=${{ vars.CLOUD_PROVIDER }}"
-    secrets: inherit
-
-  delete-cache:
-    needs: e2e-kbcli
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        type: [image, chart]
+        include:
+          - image: kubeblocks
+            dockerfile: ./docker/Dockerfile
+            context: .
+            image_repo: ${{ inputs.image_repo != '' && inputs.image_repo || format('ghcr.io/{0}/kubeblocks', github.repository_owner) }}
+          - image: kubeblocks-tools
+            dockerfile: ./docker/Dockerfile-tools
+            context: .
+            image_repo: ${{ inputs.tools_image_repo != '' && inputs.tools_image_repo || format('ghcr.io/{0}/kubeblocks-tools', github.repository_owner) }}
+          - image: kubeblocks-datascript
+            dockerfile: ./docker/Dockerfile-datascript
+            context: .
+            image_repo: ${{ inputs.datascript_image_repo != '' && inputs.datascript_image_repo || format('ghcr.io/{0}/kubeblocks-datascript', github.repository_owner) }}
     steps:
       - uses: actions/checkout@v4
-      - name: delete ${{ matrix.type }} cache
-        continue-on-error: true
-        run: |
-          bash .github/utils/utils.sh --type 17 --tag-name "${{ env.RELEASE_VERSION }}-${{ matrix.type }}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image_repo }}
+          tags: |
+            type=raw,value=${{ needs.release-version.outputs.release-version }}
+            type=raw,value=latest,enable=${{ needs.release-version.outputs.release-version == 'latest' }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,91 @@
+name: RELEASE-NOTES
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
+jobs:
+  build:
+    name: Generate release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install dependencies
+        run: pip install PyGithub
+      - name: Generate release notes
+        run: python ./.github/utils/generate_release_notes.py
+      - name: Commit and push to branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          COMMIT_MSG: |
+            Generating KubeBlocks release notes.
+            skip-checks: true
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          git remote -v
+          git checkout ${REL_BRANCH} || git checkout main
+          echo "BASE_BRANCH=$(git branch --show-current)" >> $GITHUB_ENV
+          git checkout -b support/pre-release-notes-${REL_VERSION}
+          git add .
+          # Only commit and push if have changes
+          git diff --quiet && git diff --staged --quiet || (git commit -m "${COMMIT_MSG}"; git push -u origin support/pre-release-notes-${REL_VERSION})
+      - name: Create pull request
+        run: |
+          gh pr create --title "Create release notes for ${{ env.REL_VERSION }}." --body "Release notes." --base ${{ env.BASE_BRANCH }} --draft
+
+      - name: Get project data
+        env:
+          ORGANIZATION: apecloud
+          PROJECT_NUMBER: 2
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectV2(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      ... on ProjectV2Field {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+          
+          echo 'PROJECT_ID='$(jq '.data.organization.projectV2.id' project_data.json) >> $GITHUB_ENV
+          echo 'STATUS_FIELD_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .id' project_data.json) >> $GITHUB_ENV
+
+      - name: Released Issue
+        run: |
+          echo 'TODO_OPTION_ID='$(jq '.data.organization.projectV2.fields.nodes[] | select(.name== "Status") | .options[] | select(.name=="Released") |.id' project_data.json) >> $GITHUB_ENV
+
+      - name: Move Released Issue
+        run: |
+          cd ${{ github.workspace }}
+          bash ${{ github.workspace }}/.github/utils/issue_release.sh \
+            ${{ env.GITHUB_TOKEN }} \
+            ${{ github.repository }} \
+            ${{ github.repository_owner }} \
+            $PROJECT_ID \
+            $STATUS_FIELD_ID \
+            ${{ env.TODO_OPTION_ID }} \
+            ${{ github.workspace }}/docs/release_notes

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,4 +1,4 @@
-name: Release Sync
+name: RELEASE-SYNC
 
 on:
   workflow_dispatch:
@@ -100,14 +100,9 @@ jobs:
     needs: update-release-kbcli
     if: ${{ github.event.action== 'released' || inputs.sync_flag == 'sealos' }}
     uses: apecloud/apecloud-cd/.github/workflows/comment-issue.yml@v0.1.16
-    strategy:
-      fail-fast: false
-      matrix:
-        app-name: [ "kubeblocks", "kubeblocks-apecloud-mysql", "kubeblocks-postgresql",
-                    "kubeblocks-mongodb", "kubeblocks-redis", "kubeblocks-kafka" ]
     with:
       GITHUB_REPO: "${{ vars.SEALOS_ISSUE_REPO }}"
       ISSUE_NUMBER: "${{ vars.SEALOS_ISSUE_NUMBER }}"
-      ISSUE_COMMENT_BODY: "/imagebuild_apps ${{ matrix.app-name }} ${{ needs.update-release-kbcli.outputs.release-version }}"
+      ISSUE_COMMENT_BODY: "/imagebuild_apps kubeblocks ${{ needs.update-release-kbcli.outputs.release-version }}"
       APECD_REF: "v0.1.16"
     secrets: inherit

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,4 +1,4 @@
-name: Release Version
+name: RELEASE-VERSION
 
 on:
   workflow_dispatch:
@@ -23,17 +23,33 @@ jobs:
       APECD_REF: "v0.1.38"
     secrets: inherit
 
+  trigger-mode:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get_trigger_mode.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: release message
+        id: get_trigger_mode
+        run: |
+          TEST_PACKAGES=`bash .github/utils/utils.sh --type 16 \
+              --trigger-type "[test]" \
+              --test-pkgs "${{ vars.TEST_PKGS }}" \
+              --test-check "${{ vars.TEST_CHECK }}" \
+              --test-pkgs-first "${{ vars.TEST_PKGS_FIRST }}" \
+              --ignore-pkgs "${{ vars.SKIP_CHECK_PKG }}"`
+          echo "matrix={\"include\":[$TEST_PACKAGES]}" >> $GITHUB_OUTPUT
+
   release-test:
+    needs: [ trigger-mode ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
-      matrix:
-        ops: [ 'manifests', 'mod-vendor', 'generate', 'lint', 'staticcheck', 'test' ]
+      matrix: ${{ fromJSON(needs.trigger-mode.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
       - name: install lib
         run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             libbtrfs-dev \
@@ -47,16 +63,18 @@ jobs:
       - name: Install golangci-lint
         if: matrix.ops == 'lint'
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
 
       - name: make ${{ matrix.ops }}
+        if: ${{ ! contains(matrix.ops, '/') }}
         run: |
           make ${{ matrix.ops }}
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          if [[ ("${{ matrix.ops }}" == 'generate' || "${{ matrix.ops }}" == 'manifests') && -n "$FILE_CHANGES" ]]; then
-              echo $FILE_CHANGES
-              echo "make "${{ matrix.ops }}" causes inconsistent files"
-              exit 1
+
+      - name: make test ${{ matrix.ops }}
+        if: ${{ contains(matrix.ops, '/') }}
+        run: |
+          if [[ -d "./${{ matrix.ops }}" ]]; then
+              make test TEST_PACKAGES=./${{ matrix.ops }}/...
           fi
 
   release-branch:
@@ -79,55 +97,12 @@ jobs:
       APECD_REF: "v0.1.38"
     secrets: inherit
 
-  release-addons-version-ent:
-    needs: release-branch
-    uses: apecloud/apecloud-cd/.github/workflows/trigger-workflow.yml@v0.1.38
-    with:
-      GITHUB_REPO: "apecloud/apecloud-addons"
-      VERSION: "${{ inputs.release_version }}"
-      BRANCH_NAME: "${{ needs.release-branch.outputs.release-branch }}"
-      WORKFLOW_ID: "release-version.yml"
-      APECD_REF: "v0.1.38"
-    secrets: inherit
-
   release-version:
     needs: [ release-addons-version ]
     runs-on: ubuntu-latest
     steps:
       - name: checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v4
-        with:
-          token: ${{ env.GITHUB_TOKEN }}
-          ref: ${{ github.ref_name }}
-
-      - name: install lib
-        run: |
-          sudo rm /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libbtrfs-dev \
-            libdevmapper-dev
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "${{ env.GO_VERSION }}"
-
-      - name: Update apis doc
-        id: update_apis_doc
-        run: |
-          make doc
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          if [[ -n "$FILE_CHANGES" ]]; then
-            echo $FILE_CHANGES
-            git config --local user.name "$GITHUB_ACTOR"
-            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-            git commit -a -m "chore: auto update apis docs"
-          fi
-          echo file_changes=$FILE_CHANGES >> $GITHUB_OUTPUT
-          
-          RELEASE_COMMIT="$(git rev-parse HEAD)"
-          echo 'RELEASE_COMMIT='${RELEASE_COMMIT} >> $GITHUB_ENV
 
       - name: Checkout kubeblocks-addons ${{ github.ref_name }}
         uses: actions/checkout@v4
@@ -135,33 +110,6 @@ jobs:
           repository: apecloud/kubeblocks-addons
           path: kubeblocks-addons
           ref: ${{ github.ref_name }}
-
-      - name: checkout kbcli code
-        uses: actions/checkout@v4
-        with:
-          repository: apecloud/kbcli
-          path: kbcli
-          ref: ${{ github.ref_name }}
-          token: ${{ env.GITHUB_TOKEN }}
-
-      - name: Update kbcli doc
-        id: update_kbcli_doc
-        run: |
-          echo "copy kbcli user docs to kubeblocks docs"
-          rm -rf ${{ github.workspace }}/docs/user_docs/cli/*
-          cp -r ${{ github.workspace }}/kbcli/docs/user_docs/cli/* ${{ github.workspace }}/docs/user_docs/cli/
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
-          git add ${{ github.workspace }}/docs/user_docs/cli/*
-          if [[ -n "$FILE_CHANGES" ]]; then
-            echo $FILE_CHANGES
-            git config --local user.name "$GITHUB_ACTOR"
-            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-            git commit -a -m "chore: auto update kbcli user docs"
-          fi
-          echo file_changes=$FILE_CHANGES >> $GITHUB_OUTPUT
-          
-          RELEASE_COMMIT="$(git rev-parse HEAD)"
-          echo 'RELEASE_COMMIT='${RELEASE_COMMIT} >> $GITHUB_ENV
 
       - name: upgrade addons version
         id: upgrade_addon_version
@@ -179,8 +127,8 @@ jobs:
                   fi
               fi
           done
-          FILE_CHANGES=`git diff --name-only ${{ env.RELEASE_COMMIT }}`
-          if [[ -n "$FILE_CHANGES" ]]; then
+          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
+          if [[ ! -z "$FILE_CHANGES" ]]; then
               echo $FILE_CHANGES
               git config --local user.name "$GITHUB_ACTOR"
               git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
@@ -191,24 +139,24 @@ jobs:
           RELEASE_COMMIT="$(git rev-parse HEAD)"
           echo 'RELEASE_COMMIT='${RELEASE_COMMIT} >> $GITHUB_ENV
 
-      - name: push changes to new branch
-        if: ${{ (steps.update_kbcli_doc.outputs.file_changes || steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name == 'main' }}
+      - name: push addons version changes to new branch
+        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name == 'main' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
-          branch: support/auto-update-${{ env.RELEASE_COMMIT }}
+          branch: support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}
 
       - name: auto create pr head new branch
-        if: ${{ (steps.update_kbcli_doc.outputs.file_changes || steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name == 'main' }}
+        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name == 'main' }}
         run: |
-          gh pr create --base "${{ github.ref }}" --head "support/auto-update-${{ env.RELEASE_COMMIT }}" --title "chore: auto upgrade addons version or update apis docs or update kbcli user docs" --body ""
+          gh pr create --head "support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}" --title "chore: auto upgrade kubeblocks addons version" --body ""
 
-      - name: push changes to ${{ github.ref_name }}
+      - name: push addons version changes
         uses: ad-m/github-push-action@master
-        if: ${{ (steps.update_kbcli_doc.outputs.file_changes || steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name != 'main' }}
+        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name != 'main' }}
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
-          branch: ${{ github.ref_name }}
+          branch: ${{ github.ref }}
 
       - name: push tag ${{ inputs.release_version }}
         uses: mathieudutour/github-tag-action@v6.1

--- a/.github/workflows/renew-issue.yml
+++ b/.github/workflows/renew-issue.yml
@@ -1,0 +1,11 @@
+name: RENEW-ISSUE
+
+on:
+  workflow_dispatch:
+
+jobs:
+  renew-sealos-issue:
+    uses: apecloud/apecloud-cd/.github/workflows/renew-issue.yml@v0.1.16
+    with:
+      APECD_REF: "v0.1.16"
+    secrets: inherit

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,4 +1,4 @@
-name: Trigger Release
+name: TRIGGER-RELEASE
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## What
- Sync GHCR-related workflows from `fix-workflow` to `fix-multiarch-0.9.3`.

## Changes
- Add `.github/workflows/publish-ghcr-images.yml` to publish only:
  - ghcr.io/<owner>/kubeblocks
  - ghcr.io/<owner>/kubeblocks-tools
  - ghcr.io/<owner>/kubeblocks-datascript
- Simplify `.github/workflows/release-image.yml` to build only the three images above.
- Default GHCR target to the repository owner for forks, while keeping labring on the company repo.

## Why
- Ensure PRs can be tested in forks without GHCR permission errors.
- Keep the company pipeline focused on the three images we actually publish.
