### PR TITLE
fix: handle component deletion when parent cluster is missing

### DIFF
--- a/controllers/apps/transformer_component_deletion.go
+++ b/controllers/apps/transformer_component_deletion.go
@@ -23,11 +23,12 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
@@ -60,7 +61,14 @@ func (t *componentDeletionTransformer) Transform(ctx graph.TransformContext, dag
 	comp := transCtx.Component
 	cluster, err := t.getCluster(transCtx, comp)
 	if err != nil {
-		return newRequeueError(requeueDuration, err.Error())
+		if !apierrors.IsNotFound(err) {
+			return newRequeueError(requeueDuration, err.Error())
+		}
+		// Cluster has been deleted, use a default cluster with Delete termination policy
+		// to allow the component deletion to proceed
+		cluster = t.newDefaultCluster(comp)
+		transCtx.Logger.Info("cluster not found, using default termination policy for component deletion",
+			"cluster", cluster.Name, "component", comp.Name)
 	}
 
 	// step1: update the component status to deleting
@@ -154,11 +162,23 @@ func (t *componentDeletionTransformer) getCluster(transCtx *componentTransformCo
 		return nil, err
 	}
 	cluster := &appsv1alpha1.Cluster{}
-	err = transCtx.Client.Get(transCtx.Context, types.NamespacedName{Name: clusterName, Namespace: comp.Namespace}, cluster)
-	if err != nil {
-		return nil, errors.New(fmt.Sprintf("failed to get cluster %s: %v", clusterName, err))
+	if err = transCtx.Client.Get(transCtx.Context, types.NamespacedName{Name: clusterName, Namespace: comp.Namespace}, cluster); err != nil {
+		return nil, err
 	}
 	return cluster, nil
+}
+
+func (t *componentDeletionTransformer) newDefaultCluster(comp *appsv1alpha1.Component) *appsv1alpha1.Cluster {
+	clusterName := comp.Labels[constant.AppInstanceLabelKey]
+	return &appsv1alpha1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: comp.Namespace,
+		},
+		Spec: appsv1alpha1.ClusterSpec{
+			TerminationPolicy: appsv1alpha1.Delete,
+		},
+	}
 }
 
 func compOwnedKinds() []client.ObjectList {


### PR DESCRIPTION
When a Cluster is deleted but its owned Components still exist, the Component controller fails to complete the deletion process. The [getCluster](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:152:0-178:1) method returns an error when the parent Cluster is not found, causing the component deletion transformer to enter an infinite requeue loop.
## Root Cause
In [transformer_component_deletion.go](cci:7://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:0:0-0:0), the [getCluster](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:152:0-178:1) function fetches the parent Cluster to determine the `TerminationPolicy` for resource cleanup. When the Cluster has already been garbage collected, the [Get](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/pkg/controllerutil/controller_common.go:519:0-531:1) call returns a `NotFound` error which is propagated as a generic error, preventing the deletion flow from proceeding.
## Solution
Added an `apierrors.IsNotFound` check in [getCluster](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:152:0-178:1). When the Cluster is not found, a placeholder Cluster object with a default [Delete](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:211:0-215:1) termination policy is returned, allowing the component deletion to proceed with sub-resource cleanup.
## Changes
- [controllers/apps/transformer_component_deletion.go](cci:7://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:0:0-0:0): Handle `NotFound` error in [getCluster](cci:1://file:///Users/james/go/src/github.com/wally/wally-kubeblocks/controllers/apps/transformer_component_deletion.go:152:0-178:1) by returning a placeholder Cluster with `TerminationPolicy: Delete`.
## Verification
- Unit test: `go test ./controllers/apps/... -run "deletion transformer" -v`
- E2E: Verified orphaned Components are automatically cleaned up after deploying the fix.'