### PR TITLE
fix: preserve legacy conn credential password and service on upgrade

### DIFF
--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -220,11 +220,31 @@ func (t *componentAccountTransformer) buildPassword(transCtx *componentTransform
 		// This is compatibility processing.
 		password = []byte(factory.GetRestorePassword(synthesizedComp))
 	}
+	if account.InitAccount && len(password) == 0 {
+		// Keep the legacy conn-credential password during upgrade so the new account secret
+		// does not drift from the password exposed by older releases.
+		password = t.getPasswordFromLegacySecret(transCtx)
+	}
 	if len(password) == 0 {
 		password, err := common.GeneratePasswordByConfig(account.PasswordGenerationPolicy)
 		return []byte(password), err
 	}
 	return password, nil
+}
+
+func (t *componentAccountTransformer) getPasswordFromLegacySecret(transCtx *componentTransformContext) []byte {
+	secretKey := types.NamespacedName{
+		Namespace: transCtx.SynthesizeComponent.Namespace,
+		Name:      fmt.Sprintf("%s-conn-credential", transCtx.SynthesizeComponent.ClusterName),
+	}
+	secret := &corev1.Secret{}
+	if err := transCtx.GetClient().Get(transCtx.GetContext(), secretKey, secret); err != nil {
+		return nil
+	}
+	if password, ok := secret.Data[constant.AccountPasswdForSecret]; ok && len(password) > 0 {
+		return password
+	}
+	return nil
 }
 
 func (t *componentAccountTransformer) buildAccountSecretWithPassword(ctx *componentTransformContext,

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -91,10 +91,30 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	for svc := range runningServices {
+		// Keep the legacy default service "{cluster}-{component}" for backward compatibility.
+		// Newer releases may no longer synthesize that exact service name, but older clients
+		// can still depend on it after upgrade.
+		if t.isLegacyService(synthesizeComp, svc) {
+			continue
+		}
 		graphCli.Delete(dag, runningServices[svc], appsutil.InDataContext4G())
 	}
 
 	return nil
+}
+
+func (t *componentServiceTransformer) isLegacyService(synthesizeComp *component.SynthesizedComponent, svcName string) bool {
+	legacyDefaultSvcName := constant.GenerateDefaultComponentServiceName(synthesizeComp.ClusterName, synthesizeComp.Name)
+	if svcName != legacyDefaultSvcName {
+		return false
+	}
+	for _, service := range synthesizeComp.ComponentServices {
+		currentSvcName := constant.GenerateComponentServiceName(synthesizeComp.ClusterName, synthesizeComp.Name, service.ServiceName)
+		if currentSvcName == legacyDefaultSvcName {
+			return false
+		}
+	}
+	return true
 }
 
 func (t *componentServiceTransformer) listOwnedServices(ctx context.Context, cli client.Reader,


### PR DESCRIPTION
zijiren/kubeblocks:credential-service-1.0.2