### PR TITLE
fix: avoid empty Mongo root account secrets

### DIFF
--- a/controllers/apps/transformer_component_account.go
+++ b/controllers/apps/transformer_component_account.go
@@ -58,7 +58,7 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	synthesizeComp := transCtx.SynthesizeComponent
 	graphCli, _ := transCtx.Client.(model.GraphClient)
 
-	if err := t.ensureLegacyMongoRootSecret(transCtx, synthesizeComp, graphCli, dag); err != nil {
+	if err := t.ensureGeneratedMongoRootSecret(transCtx, synthesizeComp, graphCli, dag); err != nil {
 		return err
 	}
 
@@ -73,7 +73,7 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 		}
 		if secret == nil {
 			if existSecret == nil {
-				t.emitMissingInitAccountSecretEvent(transCtx, synthesizeComp, account)
+				t.emitMissingAccountPasswordEvent(transCtx, synthesizeComp, account)
 			}
 			continue
 		}
@@ -94,7 +94,10 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	return nil
 }
 
-func (t *componentAccountTransformer) ensureLegacyMongoRootSecret(
+// ensureGeneratedMongoRootSecret creates the v0.9 account-root compatibility secret for
+// generated Mongo components that do not carry root in SystemAccounts. The password is
+// resolved through the normal account path, including restore and legacy conn-credential fallback.
+func (t *componentAccountTransformer) ensureGeneratedMongoRootSecret(
 	transCtx *componentTransformContext,
 	synthesizeComp *component.SynthesizedComponent,
 	graphCli model.GraphClient,
@@ -120,6 +123,12 @@ func (t *componentAccountTransformer) ensureLegacyMongoRootSecret(
 	rootAccount := appsv1alpha1.SystemAccount{
 		Name:        "root",
 		InitAccount: true,
+		PasswordGenerationPolicy: appsv1alpha1.PasswordConfig{
+			Length:     16,
+			NumDigits:  4,
+			NumSymbols: 0,
+			LetterCase: appsv1alpha1.MixedCases,
+		},
 	}
 	existSecret, err := t.checkAccountSecretExist(transCtx, synthesizeComp, rootAccount)
 	if err != nil {
@@ -129,20 +138,10 @@ func (t *componentAccountTransformer) ensureLegacyMongoRootSecret(
 		return nil
 	}
 
-	var password []byte
-	if transCtx.Cluster != nil {
-		if restorePwd := factory.GetRestorePassword(transCtx.Cluster, synthesizeComp); restorePwd != "" {
-			password = []byte(restorePwd)
-		}
+	secret, err := t.buildAccountSecret(transCtx, synthesizeComp, rootAccount)
+	if err != nil {
+		return err
 	}
-	if len(password) == 0 {
-		password = t.getLegacyConnCredentialPassword(transCtx)
-	}
-	if len(password) == 0 {
-		t.emitMissingInitAccountSecretEvent(transCtx, synthesizeComp, rootAccount)
-		return nil
-	}
-	secret := t.buildAccountSecretWithPassword(synthesizeComp, rootAccount, password)
 	graphCli.Create(dag, secret, inUniversalContext4G())
 	return nil
 }
@@ -203,29 +202,23 @@ func (t *componentAccountTransformer) buildPassword(ctx *componentTransformConte
 	// get restore password if exists during recovery.
 	password := factory.GetRestoreSystemAccountPassword(ctx.SynthesizeComponent.Annotations, ctx.SynthesizeComponent.Name, account.Name)
 	if account.InitAccount && password == "" {
-		if strings.EqualFold(account.Name, "root") && t.isMongoComponent(ctx) {
-			password = factory.GetRestorePassword(ctx.Cluster, synthesizeComp)
-			if password != "" {
-				return []byte(password), true
-			}
-			if legacyPwd := t.getLegacyConnCredentialPassword(ctx); len(legacyPwd) > 0 {
-				ctx.V(1).Info("using legacy conn-credential password for init account",
-					"component", ctx.SynthesizeComponent.Name, "account", account.Name)
-				return legacyPwd, true
-			}
-			return nil, false
-		} else {
-			// initAccount can also restore from factory.GetRestoreSystemAccountPassword(ctx.SynthesizeComponent, account).
-			// This is compatibility processing.
-			password = factory.GetRestorePassword(ctx.Cluster, synthesizeComp)
-		}
+		// initAccount can also restore from factory.GetRestoreSystemAccountPassword(ctx.SynthesizeComponent, account).
+		// This is compatibility processing.
+		password = factory.GetRestorePassword(ctx.Cluster, synthesizeComp)
 	}
 	// Try to get password from legacy conn-credential secret for backward compatibility (0.8 -> 0.9 upgrade).
 	if account.InitAccount && password == "" {
 		password = t.getPasswordFromLegacySecret(ctx)
 	}
 	if password == "" {
-		return t.generatePassword(account), true
+		if !hasPasswordGenerationPolicy(account.PasswordGenerationPolicy) {
+			return nil, false
+		}
+		generated := t.generatePassword(account)
+		if len(generated) == 0 {
+			return nil, false
+		}
+		return generated, true
 	}
 	return []byte(password), true
 }
@@ -257,31 +250,17 @@ func (t *componentAccountTransformer) isMongoComponent(ctx *componentTransformCo
 	return false
 }
 
-func (t *componentAccountTransformer) getLegacyConnCredentialPassword(ctx *componentTransformContext) []byte {
-	if ctx == nil || ctx.Cluster == nil {
-		return nil
-	}
-	secretKey := types.NamespacedName{
-		Namespace: ctx.Cluster.Namespace,
-		Name:      constant.GenerateDefaultConnCredential(ctx.Cluster.Name),
-	}
-	secret := &corev1.Secret{}
-	if err := ctx.Client.Get(ctx.Context, secretKey, secret); err != nil {
-		return nil
-	}
-	if pwd, ok := secret.Data[constant.AccountPasswdForSecret]; ok && len(pwd) > 0 {
-		return pwd
-	}
-	return nil
+func hasPasswordGenerationPolicy(config appsv1alpha1.PasswordConfig) bool {
+	return config.Length > 0
 }
 
-func (t *componentAccountTransformer) emitMissingInitAccountSecretEvent(ctx *componentTransformContext, synthesizeComp *component.SynthesizedComponent, account appsv1alpha1.SystemAccount) {
+func (t *componentAccountTransformer) emitMissingAccountPasswordEvent(ctx *componentTransformContext, synthesizeComp *component.SynthesizedComponent, account appsv1alpha1.SystemAccount) {
 	if ctx == nil || ctx.EventRecorder == nil || ctx.Component == nil || synthesizeComp == nil {
 		return
 	}
 	secretName := constant.GenerateAccountSecretName(synthesizeComp.ClusterName, synthesizeComp.Name, account.Name)
-	ctx.EventRecorder.Eventf(ctx.Component, corev1.EventTypeWarning, "InitAccountSecretMissing",
-		"missing legacy conn-credential and restore password for init account, please create secret %s manually", secretName)
+	ctx.EventRecorder.Eventf(ctx.Component, corev1.EventTypeWarning, "AccountSecretMissingPassword",
+		"missing restore password, legacy conn-credential, and valid password generation policy for account, please create secret %s manually", secretName)
 }
 
 // getPasswordFromLegacySecret attempts to get password from legacy conn-credential secret.

--- a/controllers/apps/transformer_component_account_unit_test.go
+++ b/controllers/apps/transformer_component_account_unit_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+)
+
+func TestComponentAccountTransformerGeneratedMongoRootSecret(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-db"
+		compName    = "mongodb"
+	)
+
+	newMongoContext := func(reader client.Reader) (*componentTransformContext, *graph.DAG) {
+		comp := &appsv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      constant.GenerateClusterComponentName(clusterName, compName),
+				Labels: map[string]string{
+					constant.AppManagedByLabelKey:   constant.AppName,
+					constant.AppInstanceLabelKey:    clusterName,
+					constant.KBAppComponentLabelKey: compName,
+				},
+			},
+		}
+		graphCli := model.NewGraphClient(reader)
+		dag := graph.NewDAG()
+		graphCli.Root(dag, comp, comp, model.ActionStatusPtr())
+		return &componentTransformContext{
+			Context:       context.Background(),
+			Client:        graphCli,
+			EventRecorder: nil,
+			Cluster: &appsv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      clusterName,
+				},
+			},
+			Component:     comp,
+			ComponentOrig: comp.DeepCopy(),
+			CompDef: &appsv1alpha1.ComponentDefinition{
+				Spec: appsv1alpha1.ComponentDefinitionSpec{
+					ServiceKind: "mongodb",
+				},
+			},
+			SynthesizeComponent: &component.SynthesizedComponent{
+				Namespace:      namespace,
+				ClusterName:    clusterName,
+				Name:           compName,
+				CharacterType:  constant.MongoDBCharacterType,
+				SystemAccounts: nil,
+			},
+		}, dag
+	}
+
+	newMongoContextWithRootAccount := func(reader client.Reader) (*componentTransformContext, *graph.DAG) {
+		transCtx, dag := newMongoContext(reader)
+		transCtx.SynthesizeComponent.SystemAccounts = []appsv1alpha1.SystemAccount{
+			{
+				Name:        "root",
+				InitAccount: true,
+			},
+		}
+		return transCtx, dag
+	}
+
+	accountRootSecret := func(t *testing.T, ctx *componentTransformContext, dag *graph.DAG) *corev1.Secret {
+		t.Helper()
+		graphCli := ctx.Client.(model.GraphClient)
+		objs := graphCli.FindAll(dag, &corev1.Secret{})
+		if len(objs) != 1 {
+			t.Fatalf("expected one account secret, got %d", len(objs))
+		}
+		secret, ok := objs[0].(*corev1.Secret)
+		if !ok {
+			t.Fatalf("expected a Secret, got %T", objs[0])
+		}
+		if expected := constant.GenerateAccountSecretName(clusterName, compName, "root"); secret.Name != expected {
+			t.Fatalf("expected secret name %q, got %q", expected, secret.Name)
+		}
+		if got := string(secret.Data[constant.AccountNameForSecret]); got != "root" {
+			t.Fatalf("expected account username root, got %q", got)
+		}
+		if len(secret.Data[constant.AccountPasswdForSecret]) == 0 {
+			t.Fatal("expected non-empty account password")
+		}
+		return secret
+	}
+
+	t.Run("generates password for new clusters without legacy conn-credential", func(t *testing.T) {
+		transCtx, dag := newMongoContext(&mockReader{})
+
+		if err := (&componentAccountTransformer{}).Transform(transCtx, dag); err != nil {
+			t.Fatalf("transform failed: %v", err)
+		}
+
+		secret := accountRootSecret(t, transCtx, dag)
+		if !transCtx.Client.(model.GraphClient).IsAction(dag, secret, model.ActionCreatePtr()) {
+			t.Fatal("expected account secret to be created")
+		}
+	})
+
+	t.Run("uses legacy conn-credential when present", func(t *testing.T) {
+		const legacyPassword = "legacy-root-password"
+		legacySecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      constant.GenerateDefaultConnCredential(clusterName),
+			},
+			Data: map[string][]byte{
+				constant.AccountPasswdForSecret: []byte(legacyPassword),
+			},
+		}
+		transCtx, dag := newMongoContext(&mockReader{objs: []client.Object{legacySecret}})
+
+		if err := (&componentAccountTransformer{}).Transform(transCtx, dag); err != nil {
+			t.Fatalf("transform failed: %v", err)
+		}
+
+		secret := accountRootSecret(t, transCtx, dag)
+		if got := string(secret.Data[constant.AccountPasswdForSecret]); got != legacyPassword {
+			t.Fatalf("expected legacy password %q, got %q", legacyPassword, got)
+		}
+	})
+
+	t.Run("does not create an empty root secret when existing account has no password source or policy", func(t *testing.T) {
+		transCtx, dag := newMongoContextWithRootAccount(&mockReader{})
+
+		if err := (&componentAccountTransformer{}).Transform(transCtx, dag); err != nil {
+			t.Fatalf("transform failed: %v", err)
+		}
+
+		graphCli := transCtx.Client.(model.GraphClient)
+		if objs := graphCli.FindAll(dag, &corev1.Secret{}); len(objs) != 0 {
+			t.Fatalf("expected no account secret to be created, got %d", len(objs))
+		}
+	})
+}


### PR DESCRIPTION
Keep the generated Mongo account-root compatibility path, but route it through the normal account password resolution flow. This preserves restore password and legacy conn-credential fallback from the transformer account change while avoiding duplicate Mongo-specific password lookup logic.

Do not create account secrets when no password source is available and the password generation policy is invalid or empty. This prevents converted or legacy Mongo root accounts from silently producing account-root secrets with an empty password.

Also rename the compatibility helper to clarify that it handles generated Mongo components missing root in SystemAccounts, and add focused tests for new-cluster generation, legacy password migration, and zero-policy skip.