### PR TITLE
fix: handle stale PVC app ownerReferences

### DIFF
--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/klauspost/compress/zstd"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -685,13 +686,7 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 	copyAndMergePVC := func(oldPVC, newPVC *corev1.PersistentVolumeClaim) client.Object {
 		mergeMap(&newPVC.Annotations, &oldPVC.Annotations)
 		mergeMap(&newPVC.Labels, &oldPVC.Labels)
-
-		// Clear any ownerReference from PVC to prevent owner mismatch issues
-		if len(oldPVC.GetOwnerReferences()) > 0 {
-			fmt.Printf("[PVC-FIX] Clearing ownerReference from PVC %s/%s\n",
-				oldPVC.Namespace, oldPVC.Name)
-			oldPVC.SetOwnerReferences(nil)
-		}
+		oldPVC.SetOwnerReferences(removeStaleAppsOwnerReferences(oldPVC.GetOwnerReferences()))
 
 		// resources.request.storage and accessModes support in-place update.
 		// resources.request.storage only supports volume expansion.
@@ -727,6 +722,29 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 		return copyAndMergePVC(targetObj.(*corev1.PersistentVolumeClaim), o)
 	default:
 		return newObj
+	}
+}
+
+func removeStaleAppsOwnerReferences(refs []metav1.OwnerReference) []metav1.OwnerReference {
+	if len(refs) == 0 {
+		return refs
+	}
+	retained := make([]metav1.OwnerReference, 0, len(refs))
+	for _, ref := range refs {
+		if isStaleAppsOwnerReference(ref) {
+			continue
+		}
+		retained = append(retained, ref)
+	}
+	return retained
+}
+
+func isStaleAppsOwnerReference(ref metav1.OwnerReference) bool {
+	switch ref.Kind {
+	case appsv1alpha1.ComponentKind, appsv1alpha1.ClusterKind:
+		return strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/")
+	default:
+		return false
 	}
 }
 

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -350,18 +350,46 @@ var _ = Describe("instance util test", func() {
 			Expect(equalBasicInPlaceFields(pod.(*corev1.Pod), newPod)).Should(BeTrue())
 
 			By("merge pvc")
+			controller := true
 			oldPvc := builder.NewPVCBuilder(namespace, name).
 				SetResources(corev1.ResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceStorage: resource.MustParse("1G"),
 				}}).
 				GetObject()
+			oldPvc.OwnerReferences = []metav1.OwnerReference{
+				{
+					APIVersion: "apps.kubeblocks.io/v1alpha1",
+					Kind:       "Cluster",
+					Name:       "cluster",
+					Controller: &controller,
+				},
+				{
+					APIVersion: "apps.kubeblocks.io/v1alpha1",
+					Kind:       "Component",
+					Name:       "component",
+				},
+				{
+					APIVersion: workloads.GroupVersion.String(),
+					Kind:       workloads.Kind,
+					Name:       "instanceset",
+				},
+			}
 			newPvc := builder.NewPVCBuilder(namespace, name).
 				SetResources(corev1.ResourceRequirements{Requests: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceStorage: resource.MustParse("2G"),
 				}}).
 				GetObject()
 			pvc := copyAndMerge(oldPvc, newPvc)
-			Expect(pvc).Should(Equal(newPvc))
+			mergedPVC, ok := pvc.(*corev1.PersistentVolumeClaim)
+			Expect(ok).Should(BeTrue())
+			Expect(mergedPVC.Spec).Should(Equal(newPvc.Spec))
+			Expect(mergedPVC.OwnerReferences).Should(Equal([]metav1.OwnerReference{
+				{
+					APIVersion: workloads.GroupVersion.String(),
+					Kind:       workloads.Kind,
+					Name:       "instanceset",
+				},
+			}))
 
 			By("merge other kind(secret)")
 			oldSecret := builder.NewSecretBuilder(namespace, name).

--- a/pkg/controller/kubebuilderx/utils.go
+++ b/pkg/controller/kubebuilderx/utils.go
@@ -26,8 +26,10 @@ import (
 	"strconv"
 	"strings"
 
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -71,25 +73,10 @@ func ReadObjectTree[T client.Object](ctx context.Context, reader client.Reader, 
 		for i := 0; i < l; i++ {
 			// get the underlying object
 			object := items.Index(i).Addr().Interface().(client.Object)
-			// For PVCs owned by Component (after KubeBlocks upgrade), we should include them
-			// and clear the ownerReference since PVCs should not have Component as owner.
-			// This fixes the upgrade leftover issue where some PVCs still have ownerReference
-			// pointing to Component, causing TreeLoader to skip them.
-			shouldInclude := model.IsOwnerOf(root, object)
-			if !shouldInclude {
-				if pvc, isPVC := object.(*corev1.PersistentVolumeClaim); isPVC {
-					// Check if PVC is owned by Component - include it but DON'T clear ownerReference here
-					// The clearing will happen in copyAndMergePVC during reconciliation
-					for _, ref := range pvc.GetOwnerReferences() {
-						if ref.Kind == "Component" && strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/") {
-							fmt.Printf("[PVC-FIX-LOADER] Found PVC %s/%s with Component owner %s, including in tree\n",
-								pvc.Namespace, pvc.Name, ref.Name)
-							shouldInclude = true
-							break
-						}
-					}
-				}
-			}
+			// PVCs left with KubeBlocks app-level ownerReferences should still
+			// be loaded so reconciliation can strip the stale ownerReference
+			// instead of trying to recreate the PVC.
+			shouldInclude := model.IsOwnerOf(root, object) || isPVCWithStaleAppsOwnerReference(object)
 			if len(object.GetOwnerReferences()) > 0 && !shouldInclude {
 				continue
 			}
@@ -100,6 +87,28 @@ func ReadObjectTree[T client.Object](ctx context.Context, reader client.Reader, 
 	}
 
 	return tree, nil
+}
+
+func isPVCWithStaleAppsOwnerReference(object client.Object) bool {
+	pvc, ok := object.(*corev1.PersistentVolumeClaim)
+	if !ok {
+		return false
+	}
+	for _, ref := range pvc.GetOwnerReferences() {
+		if isStaleAppsOwnerReference(ref) {
+			return true
+		}
+	}
+	return false
+}
+
+func isStaleAppsOwnerReference(ref metav1.OwnerReference) bool {
+	switch ref.Kind {
+	case appsv1alpha1.ComponentKind, appsv1alpha1.ClusterKind:
+		return strings.HasPrefix(ref.APIVersion, "apps.kubeblocks.io/")
+	default:
+		return false
+	}
 }
 
 func placement(obj client.Object) string {

--- a/pkg/controller/kubebuilderx/utils_test.go
+++ b/pkg/controller/kubebuilderx/utils_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -82,6 +83,59 @@ var _ = Describe("utils test", func() {
 				Expect(err).Should(BeNil())
 				Expect(obj).Should(Equal(pod))
 			}
+		})
+
+		It("includes PVCs with stale KubeBlocks app ownerReferences", func() {
+			controller, k8sMock := testutil.SetupK8sMock()
+			defer controller.Finish()
+
+			root := builder.NewStatefulSetBuilder(namespace, name).GetObject()
+			clusterOwnedPVC := builder.NewPVCBuilder(namespace, "data-"+name+"-0").GetObject()
+			clusterOwnedPVC.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "apps.kubeblocks.io/v1alpha1",
+				Kind:       "Cluster",
+				Name:       "cluster",
+			}}
+			componentOwnedPVC := builder.NewPVCBuilder(namespace, "data-"+name+"-1").GetObject()
+			componentOwnedPVC.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "apps.kubeblocks.io/v1alpha1",
+				Kind:       "Component",
+				Name:       "component",
+			}}
+			otherOwnedPVC := builder.NewPVCBuilder(namespace, "data-"+name+"-2").GetObject()
+			otherOwnedPVC.OwnerReferences = []metav1.OwnerReference{{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+				Name:       "job",
+			}}
+
+			k8sMock.EXPECT().
+				Get(gomock.Any(), gomock.Any(), &appsv1.StatefulSet{}, gomock.Any()).
+				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, obj *appsv1.StatefulSet, _ ...client.GetOption) error {
+					*obj = *root
+					return nil
+				}).Times(1)
+			k8sMock.EXPECT().
+				List(gomock.Any(), &corev1.PersistentVolumeClaimList{}, gomock.Any()).
+				DoAndReturn(func(_ context.Context, list *corev1.PersistentVolumeClaimList, _ ...client.ListOption) error {
+					Expect(list).ShouldNot(BeNil())
+					list.Items = []corev1.PersistentVolumeClaim{*clusterOwnedPVC, *componentOwnedPVC, *otherOwnedPVC}
+					return nil
+				}).Times(1)
+
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(root)}
+			ml := client.MatchingLabels{"foo": "bar"}
+			tree, err := ReadObjectTree[*appsv1.StatefulSet](context.Background(), k8sMock, req, ml, &corev1.PersistentVolumeClaimList{})
+			Expect(err).Should(BeNil())
+			Expect(tree.GetSecondaryObjects()).Should(HaveLen(2))
+			for _, pvc := range []*corev1.PersistentVolumeClaim{clusterOwnedPVC, componentOwnedPVC} {
+				obj, err := tree.Get(pvc)
+				Expect(err).Should(BeNil())
+				Expect(obj).Should(Equal(pvc))
+			}
+			obj, err := tree.Get(otherOwnedPVC)
+			Expect(err).Should(BeNil())
+			Expect(obj).Should(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- include PVCs with stale KubeBlocks Cluster/Component ownerReferences in TreeLoader so reconciliation can see existing PVCs
- remove only stale apps.kubeblocks.io Cluster/Component ownerReferences in copyAndMergePVC while preserving other ownerReferences

## Testing
- go test ./pkg/controller/kubebuilderx ./pkg/controller/instanceset
- git diff --check