### PR TITLE
fix: skip postProvision for stopped components

### DIFF
--- a/pkg/controller/component/component_post_provision.go
+++ b/pkg/controller/component/component_post_provision.go
@@ -91,6 +91,10 @@ func NeedDoPostProvision(ctx context.Context, cli client.Reader, actionCtx *Acti
 		return false, nil
 	}
 
+	if isComponentStopped(actionCtx.component) {
+		return false, nil
+	}
+
 	actionPreCondition := actionCtx.lifecycleActions.PostProvision.CustomHandler.PreCondition
 	if actionPreCondition != nil {
 		switch *actionPreCondition {
@@ -121,4 +125,15 @@ func NeedDoPostProvision(ctx context.Context, cli client.Reader, actionCtx *Acti
 	}
 
 	return needDoActionByCheckingJobNAnnotation(ctx, cli, actionCtx)
+}
+
+func isComponentStopped(component *appsv1alpha1.Component) bool {
+	if component == nil {
+		return false
+	}
+	if component.Spec.Stop != nil && *component.Spec.Stop {
+		return true
+	}
+	// For backward compatibility with the legacy stop path.
+	return component.Spec.Replicas == 0
 }

--- a/pkg/controller/component/component_post_provision_test.go
+++ b/pkg/controller/component/component_post_provision_test.go
@@ -156,11 +156,40 @@ var _ = Describe("Component PostProvision Test", func() {
 			Expect(err).Should(Succeed())
 
 			By("mock component status ready, should do postProvision action")
+			comp.Spec.Replicas = 1
 			comp.Status.Phase = appsv1alpha1.RunningClusterCompPhase
 			actionCtx.component = comp
 			need, err = NeedDoPostProvision(testCtx.Ctx, k8sClient, actionCtx)
 			Expect(err).Should(Succeed())
 			Expect(need).Should(BeTrue())
+
+			By("build component with RuntimeReady postProvision without workload, should requeue")
+			runtimeReadyPreCondition := appsv1alpha1.RuntimeReadyPreConditionType
+			synthesizeComp.LifecycleActions.PostProvision.CustomHandler.PreCondition = &runtimeReadyPreCondition
+			actionCtx, err = NewActionContext(cluster, comp, nil, synthesizeComp.LifecycleActions, synthesizeComp.ScriptTemplates, PostProvisionAction)
+			Expect(err).Should(Succeed())
+			need, err = NeedDoPostProvision(testCtx.Ctx, k8sClient, actionCtx)
+			Expect(err).ShouldNot(Succeed())
+			Expect(err.Error()).Should(ContainSubstring("runtime is nil when checking RuntimeReady preCondition"))
+			Expect(need).Should(BeFalse())
+
+			By("stopped component with RuntimeReady postProvision should skip postProvision")
+			comp.Spec.Stop = &[]bool{true}[0]
+			need, err = NeedDoPostProvision(testCtx.Ctx, k8sClient, actionCtx)
+			Expect(err).Should(Succeed())
+			Expect(need).Should(BeFalse())
+
+			By("zero-replica component with RuntimeReady postProvision should skip postProvision")
+			comp.Spec.Stop = nil
+			comp.Spec.Replicas = 0
+			comp.Status.Phase = appsv1alpha1.StoppingClusterCompPhase
+			need, err = NeedDoPostProvision(testCtx.Ctx, k8sClient, actionCtx)
+			Expect(err).Should(Succeed())
+			Expect(need).Should(BeFalse())
+
+			comp.Spec.Replicas = 1
+			comp.Status.Phase = appsv1alpha1.RunningClusterCompPhase
+			synthesizeComp.LifecycleActions.PostProvision.CustomHandler.PreCondition = &defaultPreCondition
 
 			By("build component with postProvision with PodList, do postProvision action and requeue waiting job")
 			pods := mockPodsForTest(cluster, 1)


### PR DESCRIPTION
Skip component postProvision reconciliation when the component is already stopped via spec.stop or the legacy replicas=0 stop path. This prevents RuntimeReady postProvision actions from blocking stop reconciliation after the workload has been scaled down to zero pods.

Do not mark postProvision as done when skipping, so the action can still run after the component is started again if the done annotation is absent. Add regression coverage for RuntimeReady, stop=true, and replicas=0 cases.