### PR TITLE
fix: unblock cluster deletion from legacy finalizers

### DIFF
--- a/controllers/apps/cluster_plan_builder.go
+++ b/controllers/apps/cluster_plan_builder.go
@@ -28,6 +28,7 @@ import (
 	snapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v3/apis/volumesnapshot/v1beta1"
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -45,7 +46,9 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
 
 const (
@@ -339,6 +342,9 @@ func (c *clusterPlanBuilder) reconcileDeleteObject(ctx context.Context, node *mo
 			return err
 		}
 	}
+	if err := removeOrphanBackupJobFinalizer(ctx, c.cli, node.Obj, clientOption(node)); err != nil {
+		return err
+	}
 	backgroundDeleteObject := func() error {
 		deletePropagation := metav1.DeletePropagationBackground
 		deleteOptions := &client.DeleteOptions{
@@ -357,6 +363,55 @@ func (c *clusterPlanBuilder) reconcileDeleteObject(ctx context.Context, node *mo
 		}
 	}
 	return nil
+}
+
+func removeOrphanBackupJobFinalizer(ctx context.Context, cli client.Client, obj client.Object, jobOpt *multicluster.ClientOption) error {
+	job, ok := obj.(*batchv1.Job)
+	if !ok {
+		return nil
+	}
+	if !controllerutil.ContainsFinalizer(job, dptypes.DataProtectionFinalizerName) {
+		return nil
+	}
+	backupKey, ok := backupKeyFromJob(job)
+	if !ok {
+		return nil
+	}
+
+	backup := &dpv1alpha1.Backup{}
+	if err := cli.Get(ctx, backupKey, backup, multicluster.InControlContext()); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		patch := client.MergeFrom(job.DeepCopy())
+		controllerutil.RemoveFinalizer(job, dptypes.DataProtectionFinalizerName)
+		return client.IgnoreNotFound(cli.Patch(ctx, job, patch, jobOpt))
+	}
+	return nil
+}
+
+func backupKeyFromJob(job *batchv1.Job) (client.ObjectKey, bool) {
+	labels := job.GetLabels()
+	if backupName := labels[dptypes.BackupNameLabelKey]; backupName != "" {
+		backupNamespace := labels[dptypes.BackupNamespaceLabelKey]
+		if backupNamespace == "" {
+			backupNamespace = job.Namespace
+		}
+		return client.ObjectKey{
+			Namespace: backupNamespace,
+			Name:      backupName,
+		}, true
+	}
+
+	for _, ownerRef := range job.GetOwnerReferences() {
+		if ownerRef.Kind == dptypes.BackupKind && ownerRef.Name != "" {
+			return client.ObjectKey{
+				Namespace: job.Namespace,
+				Name:      ownerRef.Name,
+			}, true
+		}
+	}
+	return client.ObjectKey{}, false
 }
 
 func (c *clusterPlanBuilder) reconcileStatusObject(ctx context.Context, node *model.ObjectVertex) error {

--- a/controllers/apps/deletion_compatibility_test.go
+++ b/controllers/apps/deletion_compatibility_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"context"
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+func TestKindsForCompDeleteIncludesPodDisruptionBudget(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range kindsForCompDelete() {
+		if _, ok := kind.(*policyv1.PodDisruptionBudgetList); ok {
+			return
+		}
+	}
+
+	t.Fatalf("expected component delete kinds to include PodDisruptionBudgetList")
+}
+
+func TestRemoveOrphanBackupJobFinalizer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		job                  *batchv1.Job
+		backup               *dpv1alpha1.Backup
+		wantFinalizerRemoved bool
+	}{
+		{
+			name: "removes finalizer when labeled backup job has no backup",
+			job: newBackupJob("job-with-missing-backup", map[string]string{
+				dptypes.BackupNameLabelKey:      "missing-backup",
+				dptypes.BackupNamespaceLabelKey: "default",
+			}, nil),
+			wantFinalizerRemoved: true,
+		},
+		{
+			name: "keeps finalizer when backup still exists",
+			job: newBackupJob("job-with-existing-backup", map[string]string{
+				dptypes.BackupNameLabelKey:      "existing-backup",
+				dptypes.BackupNamespaceLabelKey: "default",
+			}, nil),
+			backup: newBackup("existing-backup"),
+		},
+		{
+			name: "removes finalizer when owner referenced backup is missing",
+			job: newBackupJob("job-with-owner-ref", nil, []metav1.OwnerReference{
+				{
+					APIVersion: dpv1alpha1.GroupVersion.String(),
+					Kind:       dptypes.BackupKind,
+					Name:       "owner-ref-backup",
+				},
+			}),
+			wantFinalizerRemoved: true,
+		},
+		{
+			name: "keeps finalizer when job is not associated with a backup",
+			job:  newBackupJob("plain-job", nil, nil),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			objects := []client.Object{tt.job}
+			if tt.backup != nil {
+				objects = append(objects, tt.backup)
+			}
+			cli := newDeletionCompatibilityFakeClient(t, objects...)
+			if err := removeOrphanBackupJobFinalizer(ctx, cli, tt.job, nil); err != nil {
+				t.Fatalf("remove orphan backup job finalizer: %v", err)
+			}
+
+			got := &batchv1.Job{}
+			if err := cli.Get(ctx, client.ObjectKeyFromObject(tt.job), got); err != nil {
+				t.Fatalf("get job: %v", err)
+			}
+
+			hasFinalizer := controllerutil.ContainsFinalizer(got, dptypes.DataProtectionFinalizerName)
+			if tt.wantFinalizerRemoved && hasFinalizer {
+				t.Fatalf("expected dataprotection finalizer to be removed")
+			}
+			if !tt.wantFinalizerRemoved && !hasFinalizer {
+				t.Fatalf("expected dataprotection finalizer to be kept")
+			}
+		})
+	}
+}
+
+func newDeletionCompatibilityFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	if err := batchv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add batch scheme: %v", err)
+	}
+	if err := dpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add dataprotection scheme: %v", err)
+	}
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+func newBackupJob(name string, labels map[string]string, owners []metav1.OwnerReference) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            name,
+			Labels:          labels,
+			OwnerReferences: owners,
+			Finalizers: []string{
+				dptypes.DataProtectionFinalizerName,
+			},
+		},
+	}
+}
+
+func newBackup(name string) *dpv1alpha1.Backup {
+	return &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      name,
+		},
+	}
+}

--- a/controllers/apps/transformer_component_deletion.go
+++ b/controllers/apps/transformer_component_deletion.go
@@ -25,10 +25,11 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	"k8s.io/apimachinery/pkg/types"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
@@ -188,6 +189,7 @@ func compOwnedKinds() []client.ObjectList {
 		&corev1.ServiceAccountList{},
 		&rbacv1.RoleBindingList{},
 		&batchv1.JobList{},
+		&policyv1.PodDisruptionBudgetList{},
 		&dpv1alpha1.RestoreList{},
 		&dpv1alpha1.BackupList{},
 		&appsv1alpha1.ConfigurationList{},


### PR DESCRIPTION
Fix two legacy finalizer cases that can block Cluster deletion on v0.9.3:

- Include `PodDisruptionBudget` in the Component deletion plan so legacy PDBs with `cluster.kubeblocks.io/finalizer` can be cleaned up.
- Remove orphaned `dataprotection.kubeblocks.io/finalizer` from failed backup Jobs when the owning Backup no longer exists.

Also sync PDB RBAC into both generated RBAC and Helm chart RBAC.

## Why

Some old clusters can stay in `Deleting` even after Pods, InstanceSets, PVCs, Jobs, and other visible resources are gone. Two observed blockers were:

- PDB owned by Component, already deleting, still holding `cluster.kubeblocks.io/finalizer`.
- failed backup Job, already deleting, still holding `dataprotection.kubeblocks.io/finalizer`, while the Backup object no longer exists.