### PR TITLE
fix: stop config retry when workload has zero replicas

### DIFF
--- a/controllers/apps/configuration/sync_upgrade_policy.go
+++ b/controllers/apps/configuration/sync_upgrade_policy.go
@@ -98,6 +98,9 @@ func sync(params reconfigureParams, updatedParameters map[string]string, pods []
 		return makeReturnedStatus(ESFailedAndRetry), err
 	}
 	if len(pods) == 0 {
+		if replicas == 0 {
+			return makeReturnedStatus(ESNone), nil
+		}
 		params.Ctx.Log.Info(fmt.Sprintf("no pods to update, and retry, selector: %v", selector))
 		return makeReturnedStatus(ESRetry), nil
 	}


### PR DESCRIPTION
Fix a useless reconfigure retry for stopped / zero-replica workloads.

When no Pods are found and the expected replica count is also 0, reconfigure now returns `ESNone` instead of `ESRetry`. This avoids stale ConfigMap / Configuration retry loops for stopped clusters, while keeping the existing retry behavior for normal workloads that should still have Pods.

