### PR TITLE
fix: reduce checkRole-driven component requeues

### DIFF
--- a/controllers/apps/component_controller.go
+++ b/controllers/apps/component_controller.go
@@ -21,6 +21,7 @@ package apps
 
 import (
 	"context"
+	"reflect"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -31,10 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
@@ -229,7 +233,8 @@ func (r *ComponentReconciler) setupWithManager(mgr ctrl.Manager) error {
 		Owns(&dpv1alpha1.Restore{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.filterComponentResources)).
 		Watches(&corev1.PersistentVolumeClaim{}, handler.EnqueueRequestsFromMapFunc(r.filterComponentResources)).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.filterComponentResources)).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.filterComponentResources),
+			builder.WithPredicates(componentPodUpdatePredicate())).
 		Owns(&batchv1.Job{}).
 		Watches(&appsv1alpha1.Configuration{}, handler.EnqueueRequestsFromMapFunc(r.configurationEventHandler))
 
@@ -262,13 +267,49 @@ func (r *ComponentReconciler) setupWithMultiClusterManager(mgr ctrl.Manager, mul
 		Watch(b, &corev1.Secret{}, eventHandler).
 		Watch(b, &corev1.ConfigMap{}, eventHandler).
 		Watch(b, &corev1.PersistentVolumeClaim{}, eventHandler).
-		Watch(b, &corev1.Pod{}, eventHandler).
+		Watch(b, &corev1.Pod{}, eventHandler, builder.WithPredicates(componentPodUpdatePredicate())).
 		Watch(b, &batchv1.Job{}, eventHandler).
 		Watch(b, &corev1.ServiceAccount{}, eventHandler).
 		Watch(b, &rbacv1.RoleBinding{}, eventHandler).
 		Watch(b, &rbacv1.ClusterRoleBinding{}, eventHandler)
 
 	return b.Complete(r)
+}
+
+func componentPodUpdatePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return !isIgnoredComponentPodUpdate(e.ObjectOld, e.ObjectNew)
+		},
+	}
+}
+
+const roleChangedEventHandledAnnotationKey = "role.kubeblocks.io/event-handled"
+
+func isIgnoredComponentPodUpdate(oldObj, newObj client.Object) bool {
+	oldPod, ok := oldObj.(*corev1.Pod)
+	if !ok || oldPod == nil {
+		return false
+	}
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok || newPod == nil {
+		return false
+	}
+	oldCopy := oldPod.DeepCopy()
+	newCopy := newPod.DeepCopy()
+	normalizeIgnoredComponentPodUpdate(oldCopy)
+	normalizeIgnoredComponentPodUpdate(newCopy)
+	return reflect.DeepEqual(oldCopy, newCopy)
+}
+
+func normalizeIgnoredComponentPodUpdate(pod *corev1.Pod) {
+	pod.ResourceVersion = ""
+	pod.ManagedFields = nil
+	delete(pod.Annotations, constant.LastRoleSnapshotVersionAnnotationKey)
+	delete(pod.Annotations, roleChangedEventHandledAnnotationKey)
+	if len(pod.Annotations) == 0 {
+		pod.Annotations = nil
+	}
 }
 
 func (r *ComponentReconciler) filterComponentResources(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/controllers/apps/component_controller_unit_test.go
+++ b/controllers/apps/component_controller_unit_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestIsIgnoredComponentPodUpdate(t *testing.T) {
+	basePod := func() *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-0",
+				Namespace: "default",
+				Labels: map[string]string{
+					constant.AppManagedByLabelKey:   constant.AppName,
+					constant.AppInstanceLabelKey:    "cluster",
+					constant.KBAppComponentLabelKey: "mysql",
+					constant.RoleLabelKey:           "leader",
+					constant.AccessModeLabelKey:     "ReadWrite",
+				},
+				Annotations: map[string]string{
+					constant.LastRoleSnapshotVersionAnnotationKey: "1",
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*corev1.Pod)
+		ignored bool
+	}{
+		{
+			name: "ignores role snapshot version only",
+			mutate: func(pod *corev1.Pod) {
+				pod.Annotations[constant.LastRoleSnapshotVersionAnnotationKey] = "2"
+			},
+			ignored: true,
+		},
+		{
+			name: "ignores handled role event annotation only",
+			mutate: func(pod *corev1.Pod) {
+				pod.Annotations[roleChangedEventHandledAnnotationKey] = "count-2"
+			},
+			ignored: true,
+		},
+		{
+			name: "keeps other annotation updates",
+			mutate: func(pod *corev1.Pod) {
+				pod.Annotations["example.kubeblocks.io/other"] = "changed"
+			},
+			ignored: false,
+		},
+		{
+			name: "keeps role label updates",
+			mutate: func(pod *corev1.Pod) {
+				pod.Labels[constant.RoleLabelKey] = "follower"
+			},
+			ignored: false,
+		},
+		{
+			name: "keeps access mode updates",
+			mutate: func(pod *corev1.Pod) {
+				pod.Labels[constant.AccessModeLabelKey] = "Readonly"
+			},
+			ignored: false,
+		},
+		{
+			name: "keeps pod readiness updates",
+			mutate: func(pod *corev1.Pod) {
+				pod.Status.Conditions[0].Status = corev1.ConditionFalse
+			},
+			ignored: false,
+		},
+		{
+			name: "keeps pod deletion updates",
+			mutate: func(pod *corev1.Pod) {
+				now := metav1.Now()
+				pod.DeletionTimestamp = &now
+			},
+			ignored: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldPod := basePod()
+			newPod := oldPod.DeepCopy()
+			newPod.ResourceVersion = "2"
+			tt.mutate(newPod)
+			if got := isIgnoredComponentPodUpdate(oldPod, newPod); got != tt.ignored {
+				t.Fatalf("isIgnoredComponentPodUpdate() = %v, want %v", got, tt.ignored)
+			}
+		})
+	}
+}

--- a/pkg/controller/multicluster/manager.go
+++ b/pkg/controller/multicluster/manager.go
@@ -40,7 +40,7 @@ type Manager interface {
 
 	Own(b *builder.Builder, obj, owner client.Object) Manager
 
-	Watch(b *builder.Builder, obj client.Object, eventHandler handler.EventHandler) Manager
+	Watch(b *builder.Builder, obj client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) Manager
 }
 
 type manager struct {
@@ -79,10 +79,10 @@ func (m *manager) Own(b *builder.Builder, obj, owner client.Object) Manager {
 	return m
 }
 
-func (m *manager) Watch(b *builder.Builder, obj client.Object, eventHandler handler.EventHandler) Manager {
+func (m *manager) Watch(b *builder.Builder, obj client.Object, eventHandler handler.EventHandler, opts ...builder.WatchesOption) Manager {
 	for k, c := range m.caches {
 		if c != nil {
-			b.WatchesRawSource(source.Kind(m.caches[k], obj), eventHandler)
+			b.WatchesRawSource(source.Kind(m.caches[k], obj), eventHandler, opts...)
 		}
 	}
 	return m


### PR DESCRIPTION
Filter Component Pod watch updates that only change internal role bookkeeping annotations, including apps.kubeblocks.io/last-role-snapshot-version and role.kubeblocks.io/event-handled. Role label, access mode, readiness, deletion, and other meaningful Pod changes still enqueue the owning Component.

Allow multi-cluster watches to pass through native controller-runtime watch options so the same Pod update predicate can be applied consistently in both single-cluster and multi-cluster setups.

Add focused unit coverage for ignored annotation-only updates and meaningful Pod updates that must still trigger Component reconciliation.