### PR TITLE
fix: stop config retry for stopped components

### DIFF
--- a/controllers/apps/configuration/reconfigure_policy.go
+++ b/controllers/apps/configuration/reconfigure_policy.go
@@ -196,6 +196,13 @@ func (param *reconfigureParams) getTargetReplicas() int {
 	return int(param.ClusterComponent.Replicas)
 }
 
+func (param *reconfigureParams) isTargetStopped() bool {
+	if param.ClusterComponent.Stop != nil && *param.ClusterComponent.Stop {
+		return true
+	}
+	return param.ClusterComponent.Replicas == 0
+}
+
 func (param *reconfigureParams) podMinReadySeconds() int32 {
 	minReadySeconds := param.SynthesizedComponent.MinReadySeconds
 	return util.Max(minReadySeconds, viper.GetInt32(constant.PodMinReadySecondsEnv))

--- a/controllers/apps/configuration/sync_upgrade_policy.go
+++ b/controllers/apps/configuration/sync_upgrade_policy.go
@@ -98,6 +98,9 @@ func sync(params reconfigureParams, updatedParameters map[string]string, pods []
 		return makeReturnedStatus(ESFailedAndRetry), err
 	}
 	if len(pods) == 0 {
+		if params.isTargetStopped() {
+			return makeReturnedStatus(ESNone), nil
+		}
 		params.Ctx.Log.Info(fmt.Sprintf("no pods to update, and retry, selector: %v", selector))
 		return makeReturnedStatus(ESRetry), nil
 	}

--- a/controllers/apps/configuration/sync_upgrade_policy_test.go
+++ b/controllers/apps/configuration/sync_upgrade_policy_test.go
@@ -174,4 +174,24 @@ var _ = Describe("Reconfigure OperatorSyncPolicy", func() {
 		})
 	})
 
+	Context("sync reconfigure policy without pods test", func() {
+		DescribeTable("Should handle no pod target by component state",
+			func(replicas int, stopped bool, expectedStatus ExecStatus) {
+				mockParam := newMockReconfigureParams("operatorSyncPolicyNoPods", nil,
+					withConfigSpec("for_test", map[string]string{"a": "c b e f"}),
+					withConfigConstraintSpec(&appsv1beta1.FileFormatConfig{Format: appsv1beta1.RedisCfg}),
+					withClusterComponent(replicas))
+				if stopped {
+					mockParam.ClusterComponent.Stop = &stopped
+				}
+
+				status, err := sync(mockParam, map[string]string{"a": "c b e f"}, nil, RollingUpgradeFuncs{})
+				Expect(err).Should(Succeed())
+				Expect(status.Status).Should(BeEquivalentTo(expectedStatus))
+			},
+			Entry("stopped component", 1, true, ESNone),
+			Entry("legacy zero replicas component", 0, false, ESNone),
+			Entry("running component", 1, false, ESRetry))
+	})
+
 })


### PR DESCRIPTION
Fix repeated configuration retry for stopped components.

When a component is stopped in 0.9, `ClusterComponent.spec.stop=true` is set while `spec.replicas` may remain greater than 0. The underlying InstanceSet is scaled to 0 and no pods exist. However, the configuration sync policy only checked the target replicas and treated `pods=0` as an abnormal state, causing repeated retries and noisy logs.

## Changes

- Add stopped-state detection for reconfigure params:
  - `stop=true` means the component is stopped in the current 0.9 mechanism.
  - `replicas=0` is kept as backward compatibility for the legacy stop mechanism.
- Update sync dynamic reload policy:
  - If no pods are found and the target component is stopped, return success instead of retrying.
  - If no pods are found but the component is not stopped, keep the original retry behavior.
- Add tests for no-pod sync behavior:
  - `stop=true + replicas>0 + pods=0` should not retry.
  - `replicas=0 + pods=0` should not retry.
  - `replicas>0 + not stopped + pods=0` should still retry.
