### PR TITLE
Fix no-op config revision finalization

### DIFF
--- a/controllers/apps/configuration/reconcile_task.go
+++ b/controllers/apps/configuration/reconcile_task.go
@@ -28,6 +28,7 @@ import (
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/configuration/core"
 	cfgutil "github.com/apecloud/kubeblocks/pkg/configuration/util"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	configctrl "github.com/apecloud/kubeblocks/pkg/controller/configuration"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -63,6 +64,11 @@ func NewTask(item appsv1alpha1.ConfigurationItemDetail, status *appsv1alpha1.Con
 			configMap := fetcher.ConfigMapObj
 			switch intctrlutil.GetConfigSpecReconcilePhase(configMap, item, status) {
 			default:
+				// A merged item may still need a metadata-only pass if the ConfigMap
+				// revision lags behind the current Configuration revision.
+				if shouldFinalizeConfigRevision(configMap, status, revision) {
+					return syncImpl(fetcher, item, status, synComponent, revision, configSpec, dependOnObjs)
+				}
 				return syncStatus(configMap, status)
 			case appsv1alpha1.CPendingPhase,
 				appsv1alpha1.CMergeFailedPhase:
@@ -73,6 +79,13 @@ func NewTask(item appsv1alpha1.ConfigurationItemDetail, status *appsv1alpha1.Con
 		},
 		Status: status,
 	}
+}
+
+func shouldFinalizeConfigRevision(configMap *corev1.ConfigMap, status *appsv1alpha1.ConfigurationItemDetailStatus, revision string) bool {
+	if configMap == nil || status == nil || revision == "" || status.UpdateRevision != revision {
+		return false
+	}
+	return configMap.Annotations[constant.ConfigurationRevision] != revision
 }
 
 func syncImpl(fetcher *Task,

--- a/controllers/apps/configuration/reconcile_task_unit_test.go
+++ b/controllers/apps/configuration/reconcile_task_unit_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package configuration
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestShouldFinalizeConfigRevision(t *testing.T) {
+	const revision = "60"
+
+	tests := []struct {
+		name      string
+		configMap *corev1.ConfigMap
+		status    *appsv1alpha1.ConfigurationItemDetailStatus
+		revision  string
+		want      bool
+	}{
+		{
+			name: "sync when status targets current revision but configmap still has old revision",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constant.ConfigurationRevision: "51",
+					},
+				},
+			},
+			status: &appsv1alpha1.ConfigurationItemDetailStatus{
+				UpdateRevision: revision,
+			},
+			revision: revision,
+			want:     true,
+		},
+		{
+			name: "skip when configmap already has current revision",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constant.ConfigurationRevision: revision,
+					},
+				},
+			},
+			status: &appsv1alpha1.ConfigurationItemDetailStatus{
+				UpdateRevision: revision,
+			},
+			revision: revision,
+		},
+		{
+			name: "skip when status has not advanced to current revision",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constant.ConfigurationRevision: "51",
+					},
+				},
+			},
+			status: &appsv1alpha1.ConfigurationItemDetailStatus{
+				UpdateRevision: "51",
+			},
+			revision: revision,
+		},
+		{
+			name:     "skip without configmap",
+			status:   &appsv1alpha1.ConfigurationItemDetailStatus{UpdateRevision: revision},
+			revision: revision,
+		},
+		{
+			name: "skip without status",
+			configMap: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constant.ConfigurationRevision: "51",
+					},
+				},
+			},
+			revision: revision,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldFinalizeConfigRevision(tt.configMap, tt.status, tt.revision); got != tt.want {
+				t.Fatalf("shouldFinalizeConfigRevision() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/configuration/pipeline.go
+++ b/pkg/controller/configuration/pipeline.go
@@ -56,6 +56,7 @@ type pipeline struct {
 
 type updatePipeline struct {
 	reconcile     bool
+	metadataOnly  bool
 	renderWrapper renderWrapper
 
 	item       appsv1alpha1.ConfigurationItemDetail
@@ -261,6 +262,7 @@ func (p *updatePipeline) isDone() bool {
 
 func (p *updatePipeline) PrepareForTemplate() *updatePipeline {
 	buildTemplate := func() (err error) {
+		p.metadataOnly = false
 		p.reconcile = !intctrlutil.IsApplyConfigChanged(p.ConfigMapObj, p.item)
 		if p.isDone() {
 			return
@@ -342,7 +344,11 @@ func (p *updatePipeline) ApplyParameters() *updatePipeline {
 func (p *updatePipeline) UpdateConfigVersion(revision string) *updatePipeline {
 	return p.Wrap(func() error {
 		if p.isDone() {
-			return nil
+			if p.ConfigMapObj == nil || p.ConfigMapObj.Annotations[constant.ConfigurationRevision] == revision {
+				return nil
+			}
+			p.metadataOnly = true
+			p.newCM = p.ConfigMapObj.DeepCopy()
 		}
 
 		if err := updateConfigMetaForCM(p.newCM, &p.item, revision); err != nil {
@@ -366,13 +372,13 @@ func (p *updatePipeline) UpdateConfigVersion(revision string) *updatePipeline {
 // TODO(leon)
 func (p *updatePipeline) Sync() *updatePipeline {
 	return p.Wrap(func() error {
-		if p.ConfigConstraintObj != nil && !p.isDone() {
+		if p.ConfigConstraintObj != nil && p.reconcile {
 			if err := SyncEnvConfigmap(*p.configSpec, p.newCM, &p.ConfigConstraintObj.Spec, p.Client, p.Context); err != nil {
 				return err
 			}
 		}
 		switch {
-		case p.isDone():
+		case p.isDone() && !p.metadataOnly:
 			return nil
 		case p.ConfigMapObj == nil && p.newCM != nil:
 			return p.Client.Create(p.Context, p.newCM)

--- a/pkg/controller/configuration/pipeline_test.go
+++ b/pkg/controller/configuration/pipeline_test.go
@@ -21,6 +21,7 @@ package configuration
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +36,7 @@ import (
 	appsv1beta1 "github.com/apecloud/kubeblocks/apis/apps/v1beta1"
 	cfgcore "github.com/apecloud/kubeblocks/pkg/configuration/core"
 	cfgutil "github.com/apecloud/kubeblocks/pkg/configuration/util"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -73,6 +75,11 @@ var _ = Describe("ConfigurationPipelineTest", func() {
 				if client.ObjectKeyFromObject(obj) == client.ObjectKeyFromObject(configurationObj) {
 					configurationObj.Spec = *v.Spec.DeepCopy()
 					configurationObj.Status = *v.Status.DeepCopy()
+				}
+			case *corev1.ConfigMap:
+				if client.ObjectKeyFromObject(obj) == client.ObjectKeyFromObject(configMapObj) {
+					configMapObj.ObjectMeta = *v.ObjectMeta.DeepCopy()
+					configMapObj.Data = v.DeepCopy().Data
 				}
 			}
 			return nil
@@ -223,6 +230,68 @@ max_connections = '1000'
 				SyncStatus().
 				Complete()
 			Expect(err).Should(Succeed())
+		})
+
+		It("Should update revision metadata when config item is already applied", func() {
+			const (
+				oldRevision = "1"
+				newRevision = "2"
+			)
+
+			item := appsv1alpha1.ConfigurationItemDetail{
+				Name:       configSpecName,
+				ConfigSpec: synthesizedComponent.ConfigTemplates[0].DeepCopy(),
+			}
+			configurationObj.Spec.ConfigItemDetails = []appsv1alpha1.ConfigurationItemDetail{item}
+			configurationObj.Status.ConfigurationItemStatus = []appsv1alpha1.ConfigurationItemDetailStatus{
+				{
+					Name:           configSpecName,
+					Phase:          appsv1alpha1.CMergeFailedPhase,
+					UpdateRevision: oldRevision,
+				},
+			}
+
+			appliedVersion, err := json.Marshal(item)
+			Expect(err).Should(Succeed())
+			configMapObj.Annotations = map[string]string{
+				constant.ConfigAppliedVersionAnnotationKey: string(appliedVersion),
+				constant.ConfigurationRevision:             oldRevision,
+			}
+			configMapObj.Name = cfgcore.GetComponentCfgName(clusterName, mysqlCompName, configSpecName)
+			originalData := configMapObj.DeepCopy().Data
+
+			mockAPIResource(func(key client.ObjectKey, obj client.Object) (bool, error) {
+				return false, nil
+			})
+
+			reconcileTask := NewReconcilePipeline(ReconcileCtx{
+				ResourceCtx: &ResourceCtx{
+					Client:        k8sMockClient.Client(),
+					Context:       ctx,
+					Namespace:     testCtx.DefaultNamespace,
+					ClusterName:   clusterName,
+					ComponentName: mysqlCompName,
+				},
+				Cluster:              clusterObj,
+				Component:            componentObj,
+				SynthesizedComponent: synthesizedComponent,
+				PodSpec:              synthesizedComponent.PodSpec,
+			}, item, &configurationObj.Status.ConfigurationItemStatus[0], item.ConfigSpec)
+
+			err = reconcileTask.
+				ConfigMap(configSpecName).
+				ConfigConstraints(reconcileTask.ConfigSpec().ConfigConstraintRef).
+				PrepareForTemplate().
+				RerenderTemplate().
+				ApplyParameters().
+				UpdateConfigVersion(newRevision).
+				Sync().
+				Complete()
+			Expect(err).Should(Succeed())
+
+			Expect(configMapObj.Data).Should(Equal(originalData))
+			Expect(configMapObj.Annotations[constant.ConfigurationRevision]).Should(Equal(newRevision))
+			Expect(configMapObj.Annotations[constant.ConfigAppliedVersionAnnotationKey]).Should(Equal(string(appliedVersion)))
 		})
 	})
 


### PR DESCRIPTION
Finalize ConfigMap revision metadata when a Configuration item is already merged but the ConfigMap revision still lags behind the current Configuration revision.

This lets no-op config updates advance from Merged to Finished without changing ConfigMap data.